### PR TITLE
fortune support for custom loot table, BOTH reset mode, bulk commands & GUI improvements

### DIFF
--- a/src/main/java/de/c4t4lysm/catamines/CataMines.java
+++ b/src/main/java/de/c4t4lysm/catamines/CataMines.java
@@ -1,0 +1,189 @@
+package de.c4t4lysm.catamines;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import de.c4t4lysm.catamines.commands.CataMinesHelpCommand;
+import de.c4t4lysm.catamines.commands.cmcommands.*;
+import de.c4t4lysm.catamines.commands.cmcommands.ToggleAutoInvCommand;
+import de.c4t4lysm.catamines.commands.commandhandler.CommandHandler;
+import de.c4t4lysm.catamines.commands.commandhandler.FlagCommandsHandler;
+import de.c4t4lysm.catamines.listeners.BlockListeners;
+import de.c4t4lysm.catamines.listeners.PlayerJoinListener;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.tabcompleters.CataMinesTabCompleter;
+import de.c4t4lysm.catamines.utils.UpdateChecker;
+import de.c4t4lysm.catamines.utils.configuration.FileManager;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menulisteners.MenuListener;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import de.c4t4lysm.catamines.utils.mine.placeholders.CataMinePlaceHolders;
+import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.List;
+
+public final class CataMines extends JavaPlugin {
+
+    public static String PREFIX = "§6[§bCata&aMines§6] §7";
+    private static CataMines plugin;
+    private static HashMap<Player, PlayerMenuUtility> playerMenuUtilityMap = new HashMap<Player, PlayerMenuUtility>();
+    public boolean updateAvailable = false;
+    public String availableVersion = "";
+    public boolean placeholderAPI = false;
+    private boolean autoInvEnabled = true;
+    private FileManager fileManager;
+    private WorldEditPlugin worldEditPlugin;
+
+    public static CataMines getInstance() {
+        return plugin;
+    }
+
+    public static PlayerMenuUtility getPlayerMenuUtility(Player player) {
+        if (playerMenuUtilityMap.containsKey(player)) {
+            return playerMenuUtilityMap.get(player);
+        }
+        PlayerMenuUtility playerMenuUtility = new PlayerMenuUtility(player);
+        playerMenuUtilityMap.put(player, playerMenuUtility);
+
+        return playerMenuUtility;
+    }
+
+    public static void removePlayerMenuUtility(Player player) {
+        playerMenuUtilityMap.remove(player);
+    }
+
+    public static HashMap<Player, PlayerMenuUtility> getPlayerMenuUtilityMap() {
+        return playerMenuUtilityMap;
+    }
+
+    @Override
+    public void onEnable() {
+        plugin = this;
+        worldEditPlugin = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
+        ConfigurationSerialization.registerClass(CuboidCataMine.class);
+        ConfigurationSerialization.registerClass(CataMineBlock.class);
+
+        if (!getDataFolder().exists()) {
+            getDataFolder().mkdirs();
+        }
+
+        this.fileManager = new FileManager(this);
+
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
+
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            new MineManager();
+            registerCommands();
+            registerListeners();
+        }, 1L);
+
+        new UpdateChecker(getInstance(), 96457).getVersion(version -> {
+            if (!getInstance().getDescription().getVersion().equalsIgnoreCase(version)) {
+                updateAvailable = true;
+                availableVersion = version;
+                getLogger().info("There is a new version of CataMines available: " + version);
+            }
+        });
+        int pluginId = 12889;
+        new Metrics(this, pluginId);
+
+        if (plugin.getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new CataMinePlaceHolders(this).register();
+            placeholderAPI = true;
+        }
+
+    }
+
+    @Override
+    public void onDisable() {
+
+        MineManager.getInstance().getMines().forEach(CuboidCataMine::save);
+
+        plugin = null;
+        playerMenuUtilityMap = null;
+        fileManager = null;
+        worldEditPlugin = null;
+    }
+
+    private void registerCommands() {
+        getLogger().info("Starting mines and registering commands. Running version " + getDescription().getVersion());
+
+        CommandHandler commandHandler = new CommandHandler();
+        commandHandler.register("help", new CataMinesHelpCommand());
+
+        commandHandler.register("create", new CreateCommand());
+        commandHandler.register("delete", new DeleteCommand());
+        commandHandler.register("redefine", new RedefineCommand());
+        commandHandler.register("info", new InfoCommand());
+        commandHandler.register("list", new ListCommand());
+        commandHandler.register("resetmode", new ResetMode());
+        commandHandler.register("setallresetmode", new SetAllResetModeCommand());
+        commandHandler.register("setallmine", new SetAllMineCommand());
+        commandHandler.register("setdelay", new SetDelayCommand());
+        commandHandler.register("resetpercentage", new ResetPercentage());
+        commandHandler.register("set", new SetCommand());
+        commandHandler.register("unset", new UnsetCommand());
+        commandHandler.register("reset", new ResetCommand());
+        commandHandler.register("flag", new FlagCommandsHandler());
+        commandHandler.register("start", new StartCommand());
+        commandHandler.register("stop", new StopCommand());
+        commandHandler.register("starttasks", new StartTasksCommand());
+        commandHandler.register("stoptasks", new StopTasksCommand());
+        commandHandler.register("tp", new TeleportCommand());
+        commandHandler.register("settp", new SetTeleportCommand());
+        commandHandler.register("setresettp", new SetResetTeleportCommand());
+        commandHandler.register("reload", new ReloadCommand());
+        commandHandler.register("sync", new SyncCommand());
+
+        commandHandler.register("gui", new GuiCommand());
+        commandHandler.register("toggleautoinv", new ToggleAutoInvCommand());
+        getCommand("catamines").setExecutor(commandHandler);
+
+        getCommand("catamines").setTabCompleter(new CataMinesTabCompleter());
+    }
+
+    private void registerListeners() {
+        getLogger().info("Registering listeners");
+        PluginManager pm = getServer().getPluginManager();
+        pm.registerEvents(new BlockListeners(), this);
+        pm.registerEvents(new MenuListener(), this);
+    }
+
+    public FileManager getFileManager() {
+        return fileManager;
+    }
+
+    public String getDefaultString(String str) {
+        return fileManager.getDefaultString(str);
+    }
+
+    public String getLangString(String str) {
+        return fileManager.getLangString(str);
+    }
+
+    public List<String> getLangStringList(String str) {
+        return fileManager.getLangStringList(str);
+    }
+
+    public void reloadLanguages() {
+        reloadConfig();
+        fileManager.setupLanguageFiles();
+    }
+
+    public WorldEditPlugin getWorldEditPlugin() {
+        return worldEditPlugin;
+    }
+
+    public boolean isAutoInvEnabled() {
+        return autoInvEnabled;
+    }
+
+    public void setAutoInvEnabled(boolean autoInvEnabled) {
+        this.autoInvEnabled = autoInvEnabled;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/CataMinesHelpCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/CataMinesHelpCommand.java
@@ -1,0 +1,41 @@
+package de.c4t4lysm.catamines.commands;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class CataMinesHelpCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.help")) {
+            sender.sendMessage("");
+            sender.sendMessage("      §4§lC§ca§6t§ea§a§lM§bi§3n§9e§1s");
+            sender.sendMessage("§7Running version §a" + CataMines.getInstance().getDescription().getVersion());
+            sender.sendMessage("");
+            return true;
+        }
+
+        sender.sendMessage(CataMines.PREFIX + "List of commands:");
+        sender.sendMessage("");
+        sender.sendMessage(
+                "§b/cm §agui §6(mine) §7Opens the gui.\n" +
+                        "§b/cm §alist          §7Lists every Mine.\n" +
+                        "§b/cm §ainfo §6<mine> §7Displays information of the mine.\n" +
+                        "§b/cm §acreate §6<mine> §7Creates a Mine.\n" +
+                        "§b/cm §adelete §6<mine> §7Deletes a Mine.\n" +
+                        "§b/cm §aset §6<mine> [block] (%) §7Sets the block (%) of the mine.\n" +
+                        "§b/cm §aunset §6<mine> (block) §7Unsets the block of the mine.\n" +
+                        "§b/cm §asetdelay §6<mine> [delay] §7Sets the reset timer in seconds.\n" +
+                        "§b/cm §areset §6<mine> §7Resets a mine manually\n" +
+                        "§b/cm §aflag §6<mine> <flag> §7Sets a flag for the mine.\n" +
+                        "§b/cm §astart §6<mine> §7Starts the mine.\n" +
+                        "§b/cm §astop §6<mine> §7Stops the mine.\n" +
+                        "§b/cm §atp §6<mine> §7Teleports to the mine.\n" +
+                        "§b/cm §asettp §6<mine> §7Sets the teleport of the mine.\n" +
+                        "§b/cm §asetresettp §6<mine> §7Sets the reset teleport location of the mine.\n" +
+                        "§b/cm §areload §6<mine> §7Reloads mines from config when it was manually changed.");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/CommandInterface.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/CommandInterface.java
@@ -1,0 +1,17 @@
+package de.c4t4lysm.catamines.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.Collections;
+import java.util.List;
+
+public interface CommandInterface {
+
+    boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args);
+
+    default List<String> aliases() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/CreateCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/CreateCommand.java
@@ -1,0 +1,50 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.regions.Region;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CreateCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + "Only players may execute this command!");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("catamines.create")) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+
+            if (MineManager.getInstance().getMineListNames().contains(args[1])) {
+                player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Exist"));
+                return true;
+            }
+
+            WorldEditPlugin worldEditPlugin = CataMines.getInstance().getWorldEditPlugin();
+            Region selection = Utils.getWorldEditSelectionOfPlayer(worldEditPlugin, player);
+            if (selection != null) {
+
+                CuboidCataMine cuboidCataMine = new CuboidCataMine(args[1], selection.clone());
+                MineManager.getInstance().getMines().add(cuboidCataMine);
+                cuboidCataMine.save();
+                player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Create").replaceAll("%mine%", args[1]));
+            }
+        } else player.sendMessage(CataMines.PREFIX + "/cm create <mine>");
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/DeleteCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/DeleteCommand.java
@@ -1,0 +1,43 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.io.File;
+
+public class DeleteCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.delete")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMineToDelete = MineManager.getInstance().getMine(args[1]);
+            MineManager.getInstance().getMines().removeIf(mine -> mine.getName().equals(args[1]));
+            File file = new File(CataMines.getInstance().getDataFolder() + "/mines/" + cuboidCataMineToDelete.getName() + ".yml");
+            file.delete();
+
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Delete").replaceAll("%mine%", args[1]));
+
+            Utils.updateMenus();
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm delete <mine>");
+
+        return true;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/GuiCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/GuiCommand.java
@@ -1,0 +1,54 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineListMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GuiCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("catamines.gui")) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+
+        if (args.length == 1) {
+
+            if (CataMines.getPlayerMenuUtility(player).getMenu() == null) {
+                new MineListMenu(CataMines.getPlayerMenuUtility(player)).open();
+            } else {
+                CataMines.getPlayerMenuUtility(player).getMenu().open();
+            }
+
+        } else if (args.length == 2) {
+
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            new MineMenu(CataMines.getPlayerMenuUtility(player), MineManager.getInstance().getMine(args[1])).open();
+
+        } else {
+            player.sendMessage(CataMines.PREFIX + "§b/cm gui (mine)");
+        }
+
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/InfoCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/InfoCommand.java
@@ -1,0 +1,111 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+
+public class InfoCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.info")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            // Header of the info
+            sender.sendMessage(CataMines.PREFIX + "Information of §c" + args[1] + "§7:\n" +
+                    "--------------------------------");
+
+            // Displays the region
+            TextComponent component = new TextComponent("Unable to load region");
+            if (cuboidCataMine.getRegion() != null) {
+                String[] strings = Utils.regionToArray(cuboidCataMine.getRegion());
+                String regionString = "§bRegion:" + "\n" +
+                        "  §6World: §c" + strings[0] + "\n" +
+                        "    §6p1:" + "\n" +
+                        "      §7x1: §c" + strings[1] + "\n" +
+                        "      §7y1: §c" + strings[2] + "\n" +
+                        "      §7z1: §c" + strings[3] + "\n" +
+                        "    §6p2:" + "\n" +
+                        "      §7x2: §c" + strings[4] + "\n" +
+                        "      §7y2: §c" + strings[5] + "\n" +
+                        "      §7z2: §c" + strings[6];
+
+                component = new TextComponent(regionString);
+                component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("§aClick to teleport!")));
+                component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cm tp " + cuboidCataMine.getName()));
+            }
+            sender.spigot().sendMessage(component);
+
+            sender.sendMessage("§7--------------------------------");
+            sender.sendMessage("§bComposition:");
+            cuboidCataMine.getBlocks().forEach(block -> sender.sendMessage("  " + ChatColor.GOLD + block.getBlockData().getAsString(true) + ChatColor.AQUA + " , " + ChatColor.RED + block.getChance() + "%"));
+
+            sender.sendMessage("§7--------------------------------");
+            sender.sendMessage(
+                    "§bReset mode: §6" + cuboidCataMine.getResetMode().name() +
+                            "\n§bReset delay: §c" + cuboidCataMine.getResetDelay() + " §7seconds." +
+                            "\n§bReset percentage: §c" + cuboidCataMine.getResetPercentage() + "%" +
+                            "\n§bReplace mode: §c" + cuboidCataMine.isReplaceMode() +
+                            "\n§bTeleports players: §c" + cuboidCataMine.isTeleportPlayers() +
+                            "\n§bCould run: §c" + cuboidCataMine.checkRunnable() +
+                            "\n§bStopped: §c" + cuboidCataMine.isStopped() +
+                            "\n§bResets in: §c" + (cuboidCataMine.isRunnable() && !cuboidCataMine.isStopped() ? cuboidCataMine.getCountdown() + " §7seconds" : "Mine is inactive"));
+
+
+            sender.sendMessage("§7--------------------------------");
+            sender.sendMessage("§6Warning configuration:");
+
+            sender.sendMessage("§6Warnings enabled: §c" + cuboidCataMine.isWarn()
+                    + "\n§6Warns globally: §c" + cuboidCataMine.isWarnGlobal() + "\n" +
+                    "§6Warns in hotbar: §c" + cuboidCataMine.isWarnHotbar());
+
+            sender.sendMessage("§7--------------------------------");
+            sender.sendMessage("§6Messages:");
+
+            String warnMessage = ChatColor.translateAlternateColorCodes('&', cuboidCataMine.getWarnMessage().replaceAll("%cm%", StringUtils.chop(CataMines.PREFIX)).replaceAll("%mine%", cuboidCataMine.getName()));
+            Arrays.stream(warnMessage.split("/n")).forEach(sender::sendMessage);
+
+            String resetMessage = ChatColor.translateAlternateColorCodes('&', cuboidCataMine.getResetMessage().replaceAll("%cm%", StringUtils.chop(CataMines.PREFIX)).replaceAll("%mine%", cuboidCataMine.getName()));
+            Arrays.stream(resetMessage.split("/n")).forEach(sender::sendMessage);
+
+            String hotbarMessageTime = ChatColor.translateAlternateColorCodes('&', cuboidCataMine.getWarnHotbarMessage(CataMineResetMode.TIME).replaceAll("%mine%", cuboidCataMine.getName()));
+            sender.sendMessage(hotbarMessageTime);
+
+            String hotbarMessagePer = ChatColor.translateAlternateColorCodes('&', cuboidCataMine.getWarnHotbarMessage(CataMineResetMode.PERCENTAGE).replaceAll("%mine%", cuboidCataMine.getName()));
+            sender.sendMessage(hotbarMessagePer);
+
+            sender.sendMessage("");
+
+            String warnSeconds = cuboidCataMine.getWarnSeconds().toString();
+            sender.sendMessage("§6Warns on seconds: §e" + warnSeconds.substring(1, warnSeconds.length() - 1)
+                    + "\n§6Warn distance: §e" + cuboidCataMine.getWarnDistance());
+
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm info <mine>");
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ListCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ListCommand.java
@@ -1,0 +1,28 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public class ListCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.list")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 1) {
+            List<String> mineList = MineManager.getInstance().getMineListNames();
+            String str = mineList.toString().replaceAll(",", "§b,§6");
+            sender.sendMessage(CataMines.PREFIX + "These are the registered mines:\n§6" + str.substring(1, str.length() - 1));
+        } else sender.sendMessage(CataMines.PREFIX + "/cm list");
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/RedefineCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/RedefineCommand.java
@@ -1,0 +1,46 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.regions.Region;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class RedefineCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("catamines.redefine")) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+
+            WorldEditPlugin worldEditPlugin = CataMines.getInstance().getWorldEditPlugin();
+            Region selection = Utils.getWorldEditSelectionOfPlayer(worldEditPlugin, player);
+            if (selection != null) {
+                CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+                cuboidCataMine.setRegion(selection.clone());
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Move-Region").replaceAll("%mine%", args[1]));
+                cuboidCataMine.save();
+            }
+        } else player.sendMessage(CataMines.PREFIX + "/cm redefine <mine>");
+
+        return true;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ReloadCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ReloadCommand.java
@@ -1,0 +1,59 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ReloadCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.reload")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 1) {
+            CataMines.getPlayerMenuUtilityMap().clear();
+            CataMines.getInstance().getFileManager().setupFiles();
+            MineManager.getInstance().reloadMines();
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reload.All"));
+            return true;
+        }
+
+        if (args.length == 2) {
+
+            if (args[1].equalsIgnoreCase("mines")) {
+                MineManager.getInstance().reloadMines();
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reload.Mines"));
+                return true;
+            }
+
+            if (args[1].equalsIgnoreCase("properties")) {
+                CataMines.getInstance().getFileManager().setupCustomFiles();
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reload.Properties"));
+                return true;
+            }
+
+            if (args[1].equalsIgnoreCase("config")) {
+                CataMines.getInstance().getFileManager().setupConfig();
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reload.Config"));
+                return true;
+            }
+
+            if (args[1].equalsIgnoreCase("messages")) {
+                CataMines.getInstance().reloadLanguages();
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reload.Messages"));
+                return true;
+            }
+
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Unknown-Command"));
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm reload (arg)");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetCommand.java
@@ -1,0 +1,40 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ResetCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (args.length == 2) {
+
+            if (!sender.hasPermission("catamines.reset") && !sender.hasPermission("catamines.reset." + args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+                return true;
+            }
+
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            if (cuboidCataMine.getRegion() == null || cuboidCataMine.getRandomPattern() == null) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Cant-Reset").replaceAll("%mine%", args[1]));
+                return true;
+            }
+
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reset"));
+            cuboidCataMine.forceReset();
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm reset <mine>");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetMode.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetMode.java
@@ -1,0 +1,49 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ResetMode implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.resetmode")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 3) {
+            sender.sendMessage(CataMines.PREFIX + "/cm resetmode <mine> <mode>");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        if (!(args[2].equalsIgnoreCase("time") || args[2].equalsIgnoreCase("percentage") || args[2].equalsIgnoreCase("both") || args[2].equalsIgnoreCase("time_percentage"))) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Reset-Mode"));
+            return true;
+        }
+
+        CuboidCataMine mine = MineManager.getInstance().getMine(args[1]);
+
+        // Map "both" alias to TIME_PERCENTAGE
+        String modeArg = args[2].equalsIgnoreCase("both") ? "TIME_PERCENTAGE" : args[2].toUpperCase();
+        mine.setResetMode(CataMineResetMode.valueOf(modeArg));
+
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reset-Mode")
+                .replaceAll("%mine%", mine.getName())
+                .replaceAll("%mode%", modeArg));
+
+        mine.save();
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetPercentage.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ResetPercentage.java
@@ -1,0 +1,58 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ResetPercentage implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.resetpercentage")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 3) {
+            sender.sendMessage(CataMines.PREFIX + "/cm resetpercentage <mine> <percentage>");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        String percentArg = args[2];
+        if (percentArg.endsWith("%")) percentArg = StringUtils.chop(percentArg);
+
+        double resetPercentInput;
+        try {
+            resetPercentInput = Double.parseDouble(percentArg);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Not-Number"));
+            return true;
+        }
+
+        if (resetPercentInput < 0 || resetPercentInput > 100) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Invalid-Range")
+                    .replaceAll("%start%", "0.0")
+                    .replaceAll("%end%", "100.0"));
+            return true;
+        }
+
+        CuboidCataMine mine = MineManager.getInstance().getMine(args[1]);
+        mine.setResetPercentage(resetPercentInput);
+
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Reset-Percentage")
+                .replaceAll("%mine%", mine.getName())
+                .replaceAll("%percentage%", String.valueOf(resetPercentInput)));
+
+        mine.save();
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetAllMineCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetAllMineCommand.java
@@ -1,0 +1,103 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class SetAllMineCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.setallmine")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        // /cm setallmine timer <seconds>
+        // /cm setallmine percentage <percentage>
+        if (args.length != 3) {
+            sender.sendMessage(CataMines.PREFIX + "/cm setallmine timer <seconds>");
+            sender.sendMessage(CataMines.PREFIX + "/cm setallmine percentage <percentage>");
+            return true;
+        }
+
+        String subCommand = args[1].toLowerCase();
+
+        switch (subCommand) {
+            case "timer":
+            case "time": {
+                int seconds;
+                try {
+                    seconds = Integer.parseInt(args[2]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Not-Number"));
+                    return true;
+                }
+
+                if (seconds <= 0 || seconds > 1000000) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Range")
+                            .replaceAll("%start%", "1")
+                            .replaceAll("%end%", "1000000"));
+                    return true;
+                }
+
+                int count = 0;
+                for (CuboidCataMine mine : MineManager.getInstance().getMines()) {
+                    mine.setResetDelay(seconds);
+                    mine.setCountdown(seconds);
+                    mine.save();
+                    count++;
+                }
+
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set-All-Mine-Timer")
+                        .replaceAll("%seconds%", String.valueOf(seconds))
+                        .replaceAll("%count%", String.valueOf(count)));
+                break;
+            }
+
+            case "percentage": {
+                String percentArg = args[2];
+                if (percentArg.endsWith("%")) percentArg = StringUtils.chop(percentArg);
+
+                double percentage;
+                try {
+                    percentage = Double.parseDouble(percentArg);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Not-Number"));
+                    return true;
+                }
+
+                if (percentage < 0 || percentage > 100) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Range")
+                            .replaceAll("%start%", "0.0")
+                            .replaceAll("%end%", "100.0"));
+                    return true;
+                }
+
+                int count = 0;
+                for (CuboidCataMine mine : MineManager.getInstance().getMines()) {
+                    mine.setResetPercentage(percentage);
+                    mine.save();
+                    count++;
+                }
+
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set-All-Mine-Percentage")
+                        .replaceAll("%percentage%", String.valueOf(percentage))
+                        .replaceAll("%count%", String.valueOf(count)));
+                break;
+            }
+
+            default:
+                sender.sendMessage(CataMines.PREFIX + "/cm setallmine timer <seconds>");
+                sender.sendMessage(CataMines.PREFIX + "/cm setallmine percentage <percentage>");
+                break;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetAllResetModeCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetAllResetModeCommand.java
@@ -1,0 +1,52 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class SetAllResetModeCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.setallresetmode")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 2) {
+            sender.sendMessage(CataMines.PREFIX + "/cm setallresetmode <time|percentage|both>");
+            return true;
+        }
+
+        String modeArg = args[1];
+        if (!(modeArg.equalsIgnoreCase("time")
+                || modeArg.equalsIgnoreCase("percentage")
+                || modeArg.equalsIgnoreCase("both")
+                || modeArg.equalsIgnoreCase("time_percentage"))) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Reset-Mode"));
+            return true;
+        }
+
+        // Map "both" alias to TIME_PERCENTAGE
+        String enumName = modeArg.equalsIgnoreCase("both") ? "TIME_PERCENTAGE" : modeArg.toUpperCase();
+        CataMineResetMode mode = CataMineResetMode.valueOf(enumName);
+
+        int count = 0;
+        for (CuboidCataMine mine : MineManager.getInstance().getMines()) {
+            mine.setResetMode(mode);
+            mine.save();
+            count++;
+        }
+
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set-All-Reset-Mode")
+                .replaceAll("%mode%", enumName)
+                .replaceAll("%count%", String.valueOf(count)));
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetCommand.java
@@ -1,0 +1,93 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class SetCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.set")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (!(args.length == 3 || args.length == 4)) {
+            sender.sendMessage(CataMines.PREFIX + "/cm set <mine> [block] n%, for example: §8/cm set Stone_Mine stone 50%");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        BlockData blockData = Bukkit.createBlockData(args[2].toLowerCase());
+        CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+        if (args.length == 3) {
+
+            try {
+                cuboidCataMine.addBlock(new CataMineBlock(blockData, 100 - cuboidCataMine.getCompositionChance()));
+            } catch (IllegalArgumentException ex) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set.Error")
+                        .replaceAll("%chance-over-100%", ex.getMessage())
+                        .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+                return true;
+            }
+
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set.Success")
+                    .replaceAll("%material%", blockData.getAsString(true))
+                    .replaceAll("%mine%", args[1])
+                    .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+            cuboidCataMine.save();
+            return true;
+        } else {
+
+            if (args[3].endsWith("%")) {
+                double percentInput;
+
+                try {
+                    percentInput = Double.parseDouble(StringUtils.chop(args[3]));
+                } catch (NumberFormatException ex) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Not-Number"));
+                    return true;
+                }
+
+                if (percentInput < 0 || percentInput > 100) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Invalid-Chance"));
+                    return true;
+                }
+
+                try {
+                    cuboidCataMine.addBlock(new CataMineBlock(blockData, percentInput));
+                } catch (IllegalArgumentException ex) {
+                    sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set.Error")
+                            .replaceAll("%chance-over-100%", ex.getMessage())
+                            .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+                    return true;
+                }
+
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set.Success")
+                        .replaceAll("%material%", blockData.getAsString(true))
+                        .replaceAll("%mine%", args[1])
+                        .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+                cuboidCataMine.save();
+                return true;
+            } else
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Not-Percentage"));
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetDelayCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetDelayCommand.java
@@ -1,0 +1,52 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class SetDelayCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.setdelay")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 3) {
+
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            int resetDelay;
+
+            try {
+                resetDelay = Integer.parseInt(args[2]);
+            } catch (NumberFormatException ex) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Number"));
+                return true;
+            }
+
+            if (resetDelay > 1000000) {
+                sender.sendMessage(CataMines.PREFIX + "Reset delay must be be lower than §c1000000 §7seconds.");
+                return true;
+            }
+
+            cuboidCataMine.setResetDelay(resetDelay);
+            cuboidCataMine.setCountdown(resetDelay);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Delay").replaceAll("%mine%", args[1]).replaceAll("%seconds%", args[2]));
+            cuboidCataMine.save();
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm setdelay <mine> [seconds]");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetResetTeleportCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetResetTeleportCommand.java
@@ -1,0 +1,46 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SetResetTeleportCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("catamines.setresetteleport")) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 2) {
+            player.sendMessage(CataMines.PREFIX + "§b/cm setresettp <mine>");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        CuboidCataMine cataMine = MineManager.getInstance().getMine(args[1]);
+        cataMine.setTeleportResetLocation(player.getLocation());
+        cataMine.setTeleportPlayersToResetLocation(true);
+        cataMine.save();
+        player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set-Reset-Teleport").replaceAll("%mine%", args[1]));
+
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetTeleportCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SetTeleportCommand.java
@@ -1,0 +1,45 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SetTeleportCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("catamines.setteleport")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 2) {
+            player.sendMessage(CataMines.PREFIX + "§b/cm settp <mine>");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+        cuboidCataMine.setTeleportLocation(player.getLocation());
+        cuboidCataMine.save();
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Set-Teleport").replaceAll("%mine%", args[1]));
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StartCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StartCommand.java
@@ -1,0 +1,33 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class StartCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.start")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            cuboidCataMine.setStopped(false);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Start").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "/cm start <mine>");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StartTasksCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StartTasksCommand.java
@@ -1,0 +1,28 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class StartTasksCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.stoptasks")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage(CataMines.PREFIX + "&b/cm starttasks");
+            return true;
+        }
+
+        MineManager.getInstance().setStopTasks(false);
+        sender.sendMessage(CataMines.getInstance().getLangString("Commands.Start-Tasks"));
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StopCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StopCommand.java
@@ -1,0 +1,33 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class StopCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.stop")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 2) {
+            if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            cuboidCataMine.setStopped(true);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Stop").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "/cm stop <mine>");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StopTasksCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/StopTasksCommand.java
@@ -1,0 +1,28 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class StopTasksCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.stoptasks")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage(CataMines.PREFIX + "&b/cm stoptasks");
+            return true;
+        }
+
+        MineManager.getInstance().setStopTasks(true);
+        sender.sendMessage(CataMines.getInstance().getLangString("Commands.Stop-Tasks"));
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SyncCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/SyncCommand.java
@@ -1,0 +1,26 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class SyncCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+        if (!sender.hasPermission("catamines.sync")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage(CataMines.PREFIX + "&b/cm sync");
+            return true;
+        }
+
+        MineManager.getInstance().getMines().forEach(cuboidCataMine -> cuboidCataMine.setCountdown(0));
+        sender.sendMessage(CataMines.getInstance().getLangString("Commands.Sync"));
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/TeleportCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/TeleportCommand.java
@@ -1,0 +1,60 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class TeleportCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+
+        if (args.length < 2 || args.length > 3) {
+            sender.sendMessage(CataMines.PREFIX + "§b/cm tp <mine> (player)");
+            return true;
+        }
+
+        if (!sender.hasPermission("catamines.teleport") && !sender.hasPermission("catamines.teleport." + args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+        if (cuboidCataMine.getTeleportLocation() == null) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Teleport-Error"));
+            return true;
+        }
+
+        if (args.length == 2) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+                return true;
+            }
+            Player player = (Player) sender;
+            player.teleport(cuboidCataMine.getTeleportLocation());
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Teleport.Self").replaceAll("%mine%", args[1]));
+            return true;
+        }
+
+        Player target = Bukkit.getPlayer(args[2]);
+        if (target == null) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Player-Not-Found").replaceAll("%player%", args[2]));
+            return true;
+        }
+
+        target.teleport(cuboidCataMine.getTeleportLocation());
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Teleport.Other").replaceAll("%mine%", args[1]).replaceAll("%player%", args[2]));
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ToggleAutoInvCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/ToggleAutoInvCommand.java
@@ -1,0 +1,34 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ToggleAutoInvCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.toggleautoinv")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage(CataMines.PREFIX + "/cm toggleautoinv");
+            return true;
+        }
+
+        boolean current = CataMines.getInstance().isAutoInvEnabled();
+        CataMines.getInstance().setAutoInvEnabled(!current);
+
+        if (CataMines.getInstance().isAutoInvEnabled()) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Toggle-Auto-Inv.Enabled"));
+        } else {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Toggle-Auto-Inv.Disabled"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/UnsetCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/UnsetCommand.java
@@ -1,0 +1,62 @@
+package de.c4t4lysm.catamines.commands.cmcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Bukkit;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class UnsetCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!sender.hasPermission("catamines.unset")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (!(args.length == 2 || args.length == 3)) {
+            sender.sendMessage(CataMines.PREFIX + "/cm unset <mine> (block)");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist"));
+            return true;
+        }
+
+        CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+        if (args.length == 2) {
+            cuboidCataMine.clearComposition();
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Unset.Clear")
+                    .replaceAll("%mine%", args[1]));
+        } else {
+
+            BlockData blockData = Bukkit.createBlockData(args[2].toLowerCase());
+
+            if (cuboidCataMine.containsBlockData(blockData)) {
+                cuboidCataMine.removeBlock(blockData);
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Unset.Remove.Success")
+                        .replaceAll("%material%", blockData.getAsString())
+                        .replaceAll("%mine%", args[1])
+                        .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+            } else {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Unset.Remove.Error")
+                        .replaceAll("%material%", blockData.getAsString())
+                        .replaceAll("%mine%", args[1])
+                        .replaceAll("%remainingChance%", String.valueOf(100 - cuboidCataMine.getCompositionChance())));
+                return true;
+            }
+        }
+
+        cuboidCataMine.save();
+
+        return true;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/MoveRegionCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/MoveRegionCommand.java
@@ -1,0 +1,39 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.regions.Region;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class MoveRegionCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Only-Players"));
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (args.length == 3) {
+
+            WorldEditPlugin worldEditPlugin = CataMines.getInstance().getWorldEditPlugin();
+            Region selection = Utils.getWorldEditSelectionOfPlayer(worldEditPlugin, player);
+            if (selection != null) {
+                CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+                cuboidCataMine.setRegion(selection.clone());
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Move-Region").replaceAll("%mine%", args[1]));
+                cuboidCataMine.save();
+            }
+        } else player.sendMessage(CataMines.PREFIX + "/cm flag <mine> moveRegion");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/RenameCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/RenameCommand.java
@@ -1,0 +1,34 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.io.File;
+
+public class RenameCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            if (MineManager.getInstance().getMineListNames().contains(args[3])) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Exist"));
+                return true;
+            }
+
+            File file = new File(CataMines.getInstance().getDataFolder() + "/mines/" + cuboidCataMine.getName() + ".yml");
+            cuboidCataMine.setName(args[3]);
+            file.renameTo(new File(CataMines.getInstance().getDataFolder() + "/mines/" + cuboidCataMine.getName() + ".yml"));
+            cuboidCataMine.resetFiles();
+            cuboidCataMine.save();
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Rename").replaceAll("%oldmine%", args[1]).replaceAll("%newmine%", args[3]));
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> rename [name]");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/ReplaceModeCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/ReplaceModeCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class ReplaceModeCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+
+            if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            cuboidCataMine.setReplaceMode(Boolean.parseBoolean(args[3]));
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Replace-Mode").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+            cuboidCataMine.save();
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm flag <mine> setreplacemode true/false");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/TeleportPlayersCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/TeleportPlayersCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class TeleportPlayersCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+
+            if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            cuboidCataMine.setTeleportPlayers(Boolean.parseBoolean(args[3]));
+            cuboidCataMine.save();
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Teleport-Players").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm flag <mine> teleportplayers true/false");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/TeleportPlayersToResetLocationCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/TeleportPlayersToResetLocationCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class TeleportPlayersToResetLocationCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+
+            if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            cuboidCataMine.setTeleportPlayersToResetLocation(Boolean.parseBoolean(args[3]));
+            cuboidCataMine.save();
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Teleport-Players").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm flag <mine> teleportplayerstoresetlocation true/false");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnCommand.java
@@ -1,0 +1,33 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+
+            if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+                return true;
+            }
+
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            cuboidCataMine.setWarn(Boolean.parseBoolean(args[3]));
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Enable").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+            cuboidCataMine.save();
+
+        } else sender.sendMessage(CataMines.PREFIX + "/cm warn <mine> true/false");
+
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnDistanceCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnDistanceCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnDistanceCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+            int warnDistance;
+            try {
+                warnDistance = Integer.parseInt(args[3]);
+            } catch (NumberFormatException ex) {
+                sender.sendMessage(CataMines.PREFIX + "Your distance must be an §cInteger§7.");
+                return true;
+            }
+
+            cuboidCataMine.setWarnDistance(warnDistance);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Distance").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> warndistance [distance]");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnGlobalCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnGlobalCommand.java
@@ -1,0 +1,32 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnGlobalCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length == 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+                return true;
+            }
+
+            cuboidCataMine.setWarnGlobal(Boolean.parseBoolean(args[3]));
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Global").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+            cuboidCataMine.save();
+
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> warnglobal §ctrue/false");
+
+        return true;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnHotbarCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnHotbarCommand.java
@@ -1,0 +1,33 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnHotbarCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length != 4) {
+            sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> warnhotbar true/false");
+            return true;
+        }
+
+        if (!(args[3].equalsIgnoreCase("true") || args[3].equalsIgnoreCase("false"))) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Boolean"));
+            return true;
+        }
+
+        CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+        cuboidCataMine.setWarnHotbar(Boolean.parseBoolean(args[3]));
+        sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Hotbar").replaceAll("%mine%", args[1]).replaceAll("%arg%", args[3]));
+        cuboidCataMine.save();
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnHotbarMessageCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnHotbarMessageCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnHotbarMessageCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+        if (args.length >= 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 3; i < args.length; i++) {
+                sb.append(args[i]).append(" ");
+            }
+
+            String warnMessage = sb.toString().replace('"', ' ').trim();
+            cuboidCataMine.setWarnHotbarMessage(warnMessage);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Message").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> warnhotbarmessage \"message\"");
+
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnMessageCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnMessageCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnMessageCommand implements CommandInterface {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length >= 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 3; i < args.length; i++) {
+                sb.append(args[i]).append(" ");
+            }
+
+            String warnMessage = sb.toString().replace('"', ' ').trim();
+            cuboidCataMine.setWarnMessage(warnMessage);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Message").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> warnmessage \"message\"");
+
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnResetMessageCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnResetMessageCommand.java
@@ -1,0 +1,31 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class WarnResetMessageCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
+
+        if (args.length >= 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 3; i < args.length; i++) {
+                sb.append(args[i]).append(" ");
+            }
+
+            String resetMessage = sb.toString().replace('"', ' ').trim();
+            cuboidCataMine.setResetMessage(resetMessage);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Reset-Message").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> resetmessage \"message\"");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnSecondsCommand.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/cmcommands/flagcommands/WarnSecondsCommand.java
@@ -1,0 +1,38 @@
+package de.c4t4lysm.catamines.commands.cmcommands.flagcommands;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WarnSecondsCommand implements CommandInterface {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (args.length >= 4) {
+            CuboidCataMine cuboidCataMine = MineManager.getInstance().getMine(args[1]);
+
+            List<Integer> integers = new ArrayList<>();
+            for (int i = 3; i < args.length; i++) {
+                try {
+                    integers.add(Integer.parseInt(args[i]));
+                } catch (NumberFormatException ex) {
+                    sender.sendMessage(CataMines.PREFIX + "One of those arguments was not an §cInteger§7.");
+                    return true;
+                }
+            }
+
+            cuboidCataMine.setWarnSeconds(integers);
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Commands.Flag.Warn.Warn-Seconds").replaceAll("%mine%", args[1]));
+            cuboidCataMine.save();
+        } else sender.sendMessage(CataMines.PREFIX + "For example: §b/cm flag <mine> warnseconds 1 2 3 10 20 60");
+
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/commandhandler/CommandHandler.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/commandhandler/CommandHandler.java
@@ -1,0 +1,53 @@
+package de.c4t4lysm.catamines.commands.commandhandler;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.utils.Utils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class CommandHandler implements CommandExecutor {
+
+    private static final HashMap<String, CommandInterface> commands = new HashMap<>();
+
+    public static Set<String> getCommandNames() {
+        return commands.keySet();
+    }
+
+    public void register(String name, CommandInterface cmd) {
+        commands.put(name, cmd);
+    }
+
+    public boolean exists(String name) {
+        return commands.containsKey(name);
+    }
+
+    public CommandInterface getExecutor(String name) {
+        return commands.get(name);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (args.length == 0) {
+            getExecutor("help").onCommand(sender, command, label, args);
+            return true;
+        }
+
+        if (exists(args[0].toLowerCase())) {
+            getExecutor(args[0].toLowerCase()).onCommand(sender, command, label, args);
+            Utils.updateMenus();
+        } else {
+            if (!sender.hasPermission("catamines.*")) {
+                sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+                return true;
+            }
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Unknown-Command"));
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/commands/commandhandler/FlagCommandsHandler.java
+++ b/src/main/java/de/c4t4lysm/catamines/commands/commandhandler/FlagCommandsHandler.java
@@ -1,0 +1,77 @@
+package de.c4t4lysm.catamines.commands.commandhandler;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.commands.CommandInterface;
+import de.c4t4lysm.catamines.commands.cmcommands.flagcommands.*;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class FlagCommandsHandler implements CommandInterface {
+
+    private static final HashMap<String, CommandInterface> flagCommands = new HashMap<>();
+
+    public FlagCommandsHandler() {
+        flagCommands.put("replacemode", new ReplaceModeCommand());
+        flagCommands.put("moveregion", new MoveRegionCommand());
+        flagCommands.put("rename", new RenameCommand());
+        flagCommands.put("teleportplayers", new TeleportPlayersCommand());
+        flagCommands.put("teleportplayerstoresetlocation", new TeleportPlayersToResetLocationCommand());
+        flagCommands.put("warnhotbar", new WarnHotbarCommand());
+        flagCommands.put("warnhotbarmessage", new WarnHotbarMessageCommand());
+        flagCommands.put("warn", new WarnCommand());
+        flagCommands.put("warnglobal", new WarnGlobalCommand());
+        flagCommands.put("warnmessage", new WarnMessageCommand());
+        flagCommands.put("warnresetmessage", new WarnResetMessageCommand());
+        flagCommands.put("warnseconds", new WarnSecondsCommand());
+        flagCommands.put("warndistance", new WarnDistanceCommand());
+    }
+
+    public static List<String> getFlagCommandNames() {
+        return new ArrayList<>(flagCommands.keySet());
+    }
+
+    public boolean exists(String name) {
+        return flagCommands.containsKey(name);
+    }
+
+    public CommandInterface getExecutor(String name) {
+        return flagCommands.get(name);
+    }
+
+    @Override
+
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (!sender.hasPermission("catamines.flag")) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.No-Permission"));
+            return true;
+        }
+
+        if (args.length == 1) {
+            sender.sendMessage(CataMines.PREFIX + "All available flags: \n§b" + FlagCommandsHandler.getFlagCommandNames());
+            return true;
+        } else if (args.length == 2) {
+            sender.sendMessage(CataMines.PREFIX + "§b/cm flag <mine> <flag>");
+            return true;
+        }
+
+        if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Not-Exist").replaceAll("%mine%", args[1]));
+            return true;
+        }
+
+        if (exists(args[2].toLowerCase())) {
+            getExecutor(args[2].toLowerCase()).onCommand(sender, command, label, args);
+        } else {
+            sender.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Unknown-Flag"));
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/listeners/BlockListeners.java
+++ b/src/main/java/de/c4t4lysm/catamines/listeners/BlockListeners.java
@@ -1,0 +1,55 @@
+package de.c4t4lysm.catamines.listeners;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class BlockListeners implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBlockBreak(BlockBreakEvent event) {
+        //TODO: Might want to revert to checking the gamemode
+        if (event.isCancelled() || MineManager.getInstance().tasksStopped()) {
+            return;
+        }
+
+        Location blockLocation = event.getBlock().getLocation();
+
+        for (CuboidCataMine mine : MineManager.getInstance().getMines()) {
+            if (mine.isStopped() || mine.getRegion() == null) {
+                continue;
+            }
+            if (blockLocation.getWorld().getName().equals(mine.getWorld())
+                    && mine.getRegion().contains(BlockVector3.at(blockLocation.getX(), blockLocation.getY(), blockLocation.getZ()))) {
+                mine.handleBlockBreak(event);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlace(BlockPlaceEvent event) {
+        if (event.isCancelled() || MineManager.getInstance().tasksStopped()) {
+            return;
+        }
+
+        Location blockLocation = event.getBlock().getLocation();
+
+        for (CuboidCataMine mine : MineManager.getInstance().getMines()) {
+            if (mine.isStopped() || mine.getRegion() == null) {
+                continue;
+            }
+            if (blockLocation.getWorld().getName().equals(mine.getWorld())
+                    && mine.getRegion().contains(BlockVector3.at(blockLocation.getX(), blockLocation.getY(), blockLocation.getZ()))) {
+                mine.setBlockCount(mine.getBlockCount() + 1);
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/listeners/PlayerJoinListener.java
+++ b/src/main/java/de/c4t4lysm/catamines/listeners/PlayerJoinListener.java
@@ -1,0 +1,22 @@
+package de.c4t4lysm.catamines.listeners;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerJoinListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (!player.hasPermission("catamines.*") || !CataMines.getInstance().updateAvailable || !CataMines.getInstance().getConfig().getBoolean("announceUpdate", true)) {
+            return;
+        }
+        player.sendMessage(CataMines.PREFIX + "An update for CataMines is available.\n" +
+                "Download it from: §ahttps://spigotmc.org/resources/96457/");
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/schedulers/MineManager.java
+++ b/src/main/java/de/c4t4lysm/catamines/schedulers/MineManager.java
@@ -1,0 +1,100 @@
+package de.c4t4lysm.catamines.schedulers;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.mine.AbstractCataMine;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MineManager extends BukkitRunnable {
+
+    private static MineManager INSTANCE;
+    private boolean stopTasks;
+
+    private List<CuboidCataMine> mines;
+
+    public MineManager() {
+        INSTANCE = this;
+        mines = loadMinesFromFiles();
+        this.runTaskTimer(CataMines.getInstance(), 0, 20);
+    }
+
+    public static MineManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static boolean mineExists(String name) {
+        return getInstance().getMineListNames().contains(name);
+    }
+
+    @Override
+    public void run() {
+
+        if (stopTasks) {
+            return;
+        }
+
+        for (AbstractCataMine mine : mines) {
+            mine.run();
+        }
+    }
+
+    public boolean tasksStopped() {
+        return stopTasks;
+    }
+
+    public void setStopTasks(boolean stopTasks) {
+        this.stopTasks = stopTasks;
+    }
+
+    public List<CuboidCataMine> getMines() {
+        return mines;
+    }
+
+    public CuboidCataMine getMine(String name) {
+        for (CuboidCataMine mine : mines) {
+            if (mine.getName().equals(name)) {
+                return mine;
+            }
+        }
+
+        return null;
+    }
+
+    public List<String> getMineListNames() {
+        List<String> mineNames = new ArrayList<>();
+        mines.forEach(cuboidCataMine -> mineNames.add(cuboidCataMine.getName()));
+        return mineNames;
+    }
+
+    public List<CuboidCataMine> loadMinesFromFiles() {
+        CataMines.getInstance().getLogger().info("Loading mines from files...");
+        List<CuboidCataMine> mines = new ArrayList<>();
+
+        File file = new File(CataMines.getInstance().getDataFolder() + "/mines");
+        File[] files = file.listFiles(File::isFile);
+
+        if (files == null) {
+            return mines;
+        }
+
+        for (File value : files) {
+            YamlConfiguration configurationFile = YamlConfiguration.loadConfiguration(value);
+            if (configurationFile.contains("Mine") && configurationFile.get("Mine") != null) {
+                CuboidCataMine mine = (CuboidCataMine) configurationFile.get("Mine");
+                assert mine != null;
+                mines.add(mine);
+            }
+        }
+
+        return mines;
+    }
+
+    public void reloadMines() {
+        this.mines = loadMinesFromFiles();
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/tabcompleters/CataMinesTabCompleter.java
+++ b/src/main/java/de/c4t4lysm/catamines/tabcompleters/CataMinesTabCompleter.java
@@ -1,0 +1,107 @@
+package de.c4t4lysm.catamines.tabcompleters;
+
+import de.c4t4lysm.catamines.commands.commandhandler.CommandHandler;
+import de.c4t4lysm.catamines.commands.commandhandler.FlagCommandsHandler;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CataMinesTabCompleter implements TabCompleter {
+
+    private final ArrayList<String> materials;
+
+    public CataMinesTabCompleter() {
+        materials = new ArrayList<>();
+        for (Material material : Material.values()) {
+            if (material.isBlock()) {
+                materials.add(material.toString().toLowerCase());
+            }
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+
+        if (!sender.hasPermission("catamines.*")) {
+            return Collections.emptyList();
+        }
+
+        switch (args.length) {
+            case 1: {
+                return StringUtil.copyPartialMatches(args[0], new ArrayList<>(CommandHandler.getCommandNames()), new ArrayList<>());
+            }
+            case 2:
+                List<String> correctArgs = Arrays.asList("delete", "info", "set", "unset", "start", "stop", "setdelay", "flag",
+                        "reset", "tp", "settp", "setresettp", "gui", "resetmode", "resetpercentage", "redefine");
+                if (correctArgs.contains(args[0].toLowerCase())) {
+                    return StringUtil.copyPartialMatches(args[1], MineManager.getInstance().getMineListNames(), new ArrayList<>());
+                } else if (args[0].equalsIgnoreCase("reload")) {
+                    return StringUtil.copyPartialMatches(args[1], Arrays.asList("mines", "config", "messages", "properties"), new ArrayList<>());
+                } else if (args[0].equalsIgnoreCase("setallresetmode")) {
+                    return StringUtil.copyPartialMatches(args[1], Arrays.asList("TIME", "PERCENTAGE", "BOTH"), new ArrayList<>());
+                } else if (args[0].equalsIgnoreCase("setallmine")) {
+                    return StringUtil.copyPartialMatches(args[1], Arrays.asList("timer", "percentage"), new ArrayList<>());
+                }
+                break;
+            case 3: {
+                if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                    return Collections.emptyList();
+                }
+
+                List<String> completions = new ArrayList<>();
+                switch (args[0].toLowerCase()) {
+                    case "set":
+                        return StringUtil.copyPartialMatches(args[2], materials, completions);
+                    case "unset":
+                        List<String> blockList = new ArrayList<>();
+                        MineManager.getInstance().getMine(args[1]).getBlocks().forEach(block -> blockList.add(block.getBlockData().getMaterial().name()));
+                        return StringUtil.copyPartialMatches(args[2], blockList, completions);
+                    case "setdelay":
+                        return StringUtil.copyPartialMatches(args[2], Collections.singletonList("seconds"), completions);
+                    case "flag":
+                        return StringUtil.copyPartialMatches(args[2], FlagCommandsHandler.getFlagCommandNames(), completions);
+                    case "tp":
+                        return null;
+                    case "resetmode":
+                        List<String> resetModes = Arrays.stream(CataMineResetMode.values()).map(Enum::name).collect(Collectors.toList());
+                        resetModes.add("BOTH");
+                        return StringUtil.copyPartialMatches(args[2], resetModes, completions);
+                    case "setallmine":
+                        if (args[1].equalsIgnoreCase("timer")) {
+                            return StringUtil.copyPartialMatches(args[2], Collections.singletonList("<seconds>"), completions);
+                        } else if (args[1].equalsIgnoreCase("percentage")) {
+                            return StringUtil.copyPartialMatches(args[2], Collections.singletonList("<percentage>"), completions);
+                        }
+                }
+                break;
+            }
+            case 4:
+
+                if (!MineManager.getInstance().getMineListNames().contains(args[1])) {
+                    return Collections.emptyList();
+                }
+
+                switch (args[0].toLowerCase()) {
+                    case "replacemode":
+                    case "warn":
+                    case "warnglobal":
+                    case "teleportplayers":
+                    case "teleportplayerstoresetlocation":
+                        return StringUtil.copyPartialMatches(args[3], Arrays.asList("true", "false"), new ArrayList<>());
+                }
+                break;
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/ItemStackBuilder.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/ItemStackBuilder.java
@@ -1,0 +1,88 @@
+package de.c4t4lysm.catamines.utils;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ItemStackBuilder {
+
+    public static ItemStack buildItem(Material material, final String name, final String... lore) {
+
+        final ItemStack item = new ItemStack(material, 1);
+        final ItemMeta meta = item.getItemMeta();
+
+        if (meta != null) {
+
+            // Set the name of the item
+            meta.setDisplayName(name);
+
+            // Set the lore of the item
+            meta.setLore(Arrays.asList(lore));
+
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+    public static ItemStack buildItem(Material material, final String name, final List<String> lore) {
+
+        final ItemStack item = new ItemStack(material, 1);
+        final ItemMeta meta = item.getItemMeta();
+
+        if (meta != null) {
+
+            // Set the name of the item
+            meta.setDisplayName(name);
+
+            // Set the lore of the item
+            meta.setLore(lore);
+
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+    public static ItemStack buildItem(Material material, int amount, final String name, final List<String> lore) {
+
+        final ItemStack item = new ItemStack(material, amount);
+        final ItemMeta meta = item.getItemMeta();
+
+        if (meta != null) {
+
+            // Set the name of the item
+            meta.setDisplayName(name);
+
+            // Set the lore of the item
+            meta.setLore(lore);
+
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+    public static ItemStack buildItem(Material material, int amount, final String name, final String... lore) {
+
+        final ItemStack item = new ItemStack(material, amount);
+        final ItemMeta meta = item.getItemMeta();
+
+        if (meta != null) {
+
+            // Set the name of the item
+            meta.setDisplayName(name);
+
+            // Set the lore of the item
+            meta.setLore(Arrays.asList(lore));
+
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/UpdateChecker.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/UpdateChecker.java
@@ -1,0 +1,33 @@
+package de.c4t4lysm.catamines.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Scanner;
+import java.util.function.Consumer;
+
+public class UpdateChecker {
+
+    private final JavaPlugin plugin;
+    private final int resourceId;
+
+    public UpdateChecker(JavaPlugin plugin, int resourceId) {
+        this.plugin = plugin;
+        this.resourceId = resourceId;
+    }
+
+    public void getVersion(final Consumer<String> consumer) {
+        Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
+            try (InputStream inputStream = new URL("https://api.spigotmc.org/legacy/update.php?resource=" + this.resourceId).openStream(); Scanner scanner = new Scanner(inputStream)) {
+                if (scanner.hasNext()) {
+                    consumer.accept(scanner.next());
+                }
+            } catch (IOException exception) {
+                this.plugin.getLogger().info("Cannot look for updates: " + exception.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/Utils.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/Utils.java
@@ -1,0 +1,168 @@
+package de.c4t4lysm.catamines.utils;
+
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.CompositionBlockMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.CompositionMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable.ChangeBlockLootTableMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable.LootItemListMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable.LootItemMenu;
+import de.c4t4lysm.catamines.utils.mine.AbstractCataMine;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryHolder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Utils {
+
+    public static String setPlaceholders(String input, AbstractCataMine mine) {
+
+        Map<String, String> replacements = new HashMap<>();
+        replacements.put("cm", StringUtils.chop(CataMines.PREFIX));
+        replacements.put("mine", mine.getName());
+        replacements.put("seconds", String.valueOf(mine.getCountdown()));
+        replacements.put("formattedseconds", secondsToTimeFormat(mine.getCountdown()));
+        replacements.put("formattedtime", mine.getFormattedTimeString());
+        replacements.put("time", mine.getCountdown() / 60 == 1 ?
+                CataMines.getInstance().getLangString("Time.Second") :
+                CataMines.getInstance().getLangString("Time.Seconds"));
+        replacements.put("resetpercentage", String.valueOf(mine.getResetPercentage()));
+        replacements.put("remainingblocksper", String.valueOf(mine.getRemainingBlocksPer()));
+
+        StrSubstitutor strSubstitutor = new StrSubstitutor(replacements, "%", "%");
+        String translatedText = strSubstitutor.replace(input);
+
+        if (CataMines.getInstance().placeholderAPI) {
+            translatedText = PlaceholderAPI.setPlaceholders(null, translatedText);
+        }
+
+        return ChatColor.translateAlternateColorCodes('&', translatedText);
+    }
+
+    public static String secondsToTimeFormat(int seconds) {
+        if (seconds >= 60) {
+            if (seconds >= 3600) {
+                return String.format("%d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+            }
+            return String.format("%d:%02d", seconds / 60, seconds % 60);
+        }
+        return String.valueOf(seconds);
+    }
+
+    @Nullable
+    public static String regionToStr(@Nonnull Region region) {
+        String reg = "";
+
+        if (region.getWorld() == null) return null;
+        reg += region.getWorld().getName() + ";";
+        reg += region.getMinimumPoint().getX() + ";";
+        reg += region.getMinimumPoint().getY() + ";";
+        reg += region.getMinimumPoint().getZ() + ";";
+        reg += region.getMaximumPoint().getX() + ";";
+        reg += region.getMaximumPoint().getY() + ";";
+        reg += region.getMaximumPoint().getZ() + ";";
+
+        return reg;
+    }
+
+    @Nonnull
+    public static String[] regionToArray(@Nonnull Region region) {
+        String[] strings = new String[7];
+
+        strings[0] = region.getWorld().getName();
+        BlockVector3 minP = region.getMinimumPoint();
+        BlockVector3 maxP = region.getMaximumPoint();
+        strings[1] = String.valueOf(minP.getX());
+        strings[2] = String.valueOf(minP.getY());
+        strings[3] = String.valueOf(minP.getZ());
+        strings[4] = String.valueOf(maxP.getX());
+        strings[5] = String.valueOf(maxP.getY());
+        strings[6] = String.valueOf(maxP.getZ());
+
+        return strings;
+    }
+
+    @Nullable
+    public static Region strToRegion(@Nonnull String str) {
+        String[] args = str.split(";");
+
+        if (Bukkit.getWorld(args[0]) == null) return null;
+
+        return new CuboidRegion(BukkitAdapter.adapt(Bukkit.getWorld(args[0])), BlockVector3.at(Integer.parseInt(args[1]), Integer.parseInt(args[2]), Integer.parseInt(args[3])),
+                BlockVector3.at(Integer.parseInt(args[4]), Integer.parseInt(args[5]), Integer.parseInt(args[6])));
+    }
+
+    @Nullable
+    public static Region getWorldEditSelectionOfPlayer(WorldEditPlugin worldEditPlugin, Player player) {
+        Region selection;
+
+        try {
+            if (worldEditPlugin != null) {
+                selection = worldEditPlugin.getSession(player).getSelection(BukkitAdapter.adapt(player.getWorld()));
+                return selection;
+            }
+        } catch (IncompleteRegionException ex) {
+            player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.Mine.Incomplete-Region"));
+        }
+        return null;
+    }
+
+    public static void updateMenus() {
+
+        for (Map.Entry<Player, PlayerMenuUtility> entry : CataMines.getPlayerMenuUtilityMap().entrySet()) {
+            Player player = entry.getKey();
+            PlayerMenuUtility playerMenuUtility = entry.getValue();
+
+            if (playerMenuUtility.getMine() != null && !MineManager.getInstance().getMines().contains(playerMenuUtility.getMine())) {
+                player.closeInventory();
+                CataMines.removePlayerMenuUtility(player);
+                player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Mine-Deleted"));
+                return;
+            }
+
+            if (playerMenuUtility.getMenu() instanceof CompositionBlockMenu
+                    || playerMenuUtility.getMenu() instanceof ChangeBlockLootTableMenu ||
+                    playerMenuUtility.getMenu() instanceof LootItemListMenu ||
+                    playerMenuUtility.getMenu() instanceof LootItemMenu) {
+
+                if (!playerMenuUtility.getMine().containsBlock(playerMenuUtility.getBlock())) {
+                    playerMenuUtility.setBlock(null);
+                    new CompositionMenu(playerMenuUtility);
+                    player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Block-Deleted"));
+                }
+            }
+
+            if (playerMenuUtility.getMenu() instanceof LootItemMenu) {
+                if (!playerMenuUtility.getBlock().getLootTable().contains(playerMenuUtility.getItem())) {
+                    playerMenuUtility.setItem(null);
+                    new LootItemListMenu(playerMenuUtility);
+                    player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Loot-Table-Change"));
+                }
+            }
+
+            InventoryHolder inventoryHolder = player.getOpenInventory().getTopInventory().getHolder();
+
+            if (inventoryHolder instanceof Menu) {
+                playerMenuUtility.getMenu().open();
+            }
+
+        }
+
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/configuration/CustomConfigFile.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/configuration/CustomConfigFile.java
@@ -1,0 +1,98 @@
+package de.c4t4lysm.catamines.utils.configuration;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.Objects;
+
+public class CustomConfigFile extends YamlConfiguration {
+
+    private final File file;
+
+    public CustomConfigFile(CataMines plugin, File file, String resourceName) {
+
+        this.file = file;
+
+        try {
+
+            if (!this.file.exists()) {
+                this.file.getParentFile().mkdirs();
+                this.file.createNewFile();
+            }
+
+            this.load(this.file);
+
+            Map<String, Object> mappedConfig = this.getValues(true);
+            try {
+                Files.copy(plugin.getClass().getResourceAsStream("/" + resourceName), this.file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            this.load(this.file);
+
+            for (Map.Entry<String, Object> entry : mappedConfig.entrySet()) {
+                this.set(entry.getKey(), entry.getValue());
+            }
+
+            Map<String, Object> defaultMap = YamlConfiguration.loadConfiguration(new InputStreamReader(plugin.getClass().getResourceAsStream("/" + resourceName))).getValues(true);
+            for (Map.Entry<String, Object> entry : defaultMap.entrySet()) {
+                if (this.contains(entry.getKey())) {
+                    continue;
+                }
+
+                this.set(entry.getKey(), entry.getValue());
+            }
+
+            saveConfig();
+
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public CustomConfigFile(CataMines plugin, File file, String resourceName, StandardCopyOption copyOption) {
+
+        this.file = file;
+
+        try {
+            if (!file.exists()) {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            }
+
+            InputStream is = plugin.getClass().getResourceAsStream("/" + resourceName);
+            load(new InputStreamReader(Objects.requireNonNull(is)));
+
+            saveConfig();
+
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void saveConfig() {
+        try {
+            save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void reloadConfig() {
+        try {
+            this.load(this.file);
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/configuration/FileConfig.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/configuration/FileConfig.java
@@ -1,0 +1,95 @@
+package de.c4t4lysm.catamines.utils.configuration;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FileConfig extends YamlConfiguration {
+
+    private File file;
+
+    public FileConfig(File file) {
+        this.file = file;
+
+        if (!file.exists()) {
+            try {
+                this.file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            try {
+                this.load(this.file);
+            } catch (IOException | InvalidConfigurationException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public FileConfig(String filename) {
+        String path = CataMines.getInstance().getDataFolder() + "/" + filename;
+        this.file = new File(path);
+
+        if (!file.exists()) {
+            try {
+                file.createNewFile();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        } else {
+            try {
+                this.load(file);
+            } catch (InvalidConfigurationException | IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    public FileConfig(String path, String fileName) {
+        String finalPath = path + "/" + fileName;
+        File directory = new File(path);
+
+        if (!directory.exists() && !directory.mkdirs()) {
+            return;
+        }
+
+        this.file = new File(finalPath);
+        if (!this.file.exists()) {
+            try {
+                this.file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            try {
+                this.load(this.file);
+            } catch (IOException | InvalidConfigurationException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void saveConfig() {
+        try {
+            save(file);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public void reloadConfig() {
+        try {
+            this.load(file);
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/configuration/FileManager.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/configuration/FileManager.java
@@ -1,0 +1,132 @@
+package de.c4t4lysm.catamines.utils.configuration;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FileManager {
+
+    private final CataMines plugin;
+    private final File dataFolder;
+    private FileConfig langCfg;
+    private CustomConfigFile propertiesCfg;
+
+    public FileManager(CataMines plugin) {
+        this.plugin = plugin;
+        this.dataFolder = plugin.getDataFolder();
+        setupFiles();
+    }
+
+    public String getDefaultString(String str) {
+        if (!propertiesCfg.contains(str)) {
+            return "Could not find " + str;
+        }
+        return propertiesCfg.getString(str);
+    }
+
+    public String getLangString(String str) {
+        if (!langCfg.contains(str)) {
+            return "Error loading: " + str + ", " + plugin.getConfig().getString("language");
+        }
+        return ChatColor.translateAlternateColorCodes('&', langCfg.getString(str));
+    }
+
+    public List<Integer> getDefaultIntegers(String str) {
+        if (!propertiesCfg.contains(str)) {
+            return Arrays.asList(600, 300, 60, 20, 5);
+        }
+        return propertiesCfg.getIntegerList(str);
+    }
+
+    public List<String> getLangStringList(String str) {
+        if (!langCfg.contains(str)) {
+            return Arrays.asList("Could not load ", str, "language: " + plugin.getConfig().getString("language"));
+        }
+        List<String> translatedList = new ArrayList<>();
+        langCfg.getStringList(str).forEach(s -> translatedList.add(ChatColor.translateAlternateColorCodes('&', s)));
+        return translatedList;
+    }
+
+    public void setupFiles() {
+        setupConfig();
+        setupMinesFolder();
+        setupCustomFiles();
+        setupLanguageFiles();
+    }
+
+    public void setupConfig() {
+
+        plugin.getLogger().info("Loading config file");
+        new CustomConfigFile(plugin, new File(dataFolder, "config.yml"), "config.yml");
+
+        plugin.reloadConfig();
+
+        CataMines.PREFIX = ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("prefix"));
+    }
+
+    public void setupMinesFolder() {
+        File minesDirectory = new File(plugin.getDataFolder() + "/mines");
+        if (!minesDirectory.exists() && !minesDirectory.mkdirs()) {
+            plugin.getLogger().severe("Could not create mines folder, plugin disabled!");
+            Bukkit.getPluginManager().disablePlugin(plugin);
+        }
+    }
+
+    public void setupCustomFiles() {
+
+        this.propertiesCfg = new CustomConfigFile(plugin, new File(dataFolder, "default_properties.yml"), "default_properties.yml");
+        this.propertiesCfg.saveConfig();
+
+    }
+
+    public void setupLanguageFiles() {
+
+        new CustomConfigFile(plugin, new File(dataFolder + "/languages", "messages_en.yml"), "messages_en.yml", StandardCopyOption.REPLACE_EXISTING);
+        new CustomConfigFile(plugin, new File(dataFolder + "/languages", "messages_es.yml"), "messages_es.yml", StandardCopyOption.REPLACE_EXISTING);
+        new CustomConfigFile(plugin, new File(dataFolder + "/languages", "messages_cn.yml"), "messages_cn.yml", StandardCopyOption.REPLACE_EXISTING);
+
+        new CustomConfigFile(plugin, new File(dataFolder + "/languages", "messages_custom.yml"), "messages_custom.yml");
+
+        File langFile = new File(dataFolder + "/languages", "messages_" + plugin.getConfig().getString("language").toLowerCase() + ".yml");
+        if (!langFile.exists()) {
+            plugin.getLogger().severe("The language you chose does not exist: " + langCfg.getName() + ", changing to EN");
+            langCfg = new FileConfig(new File(dataFolder + "/languages", "messages_en.yml"));
+            return;
+        }
+        langCfg = new FileConfig(new File(dataFolder + "/languages", "messages_" + plugin.getConfig().getString("language").toLowerCase() + ".yml"));
+    }
+
+    @Deprecated
+    private void setupFile(File file, boolean replace) {
+        plugin.getLogger().info("Loading " + file.getName() + ". Replaced: " + replace);
+        if (!file.exists()) {
+            try {
+                file.createNewFile();
+                InputStream is = plugin.getClass().getResourceAsStream("/" + file.getName());
+                Files.copy(is, file.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                plugin.getLogger().severe("Could not create " + file.getName() + " file.");
+            }
+        }
+
+        if (replace) {
+            InputStream is = plugin.getClass().getResourceAsStream("/" + file.getName());
+            try {
+                Files.copy(is, file.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/Menu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/Menu.java
@@ -1,0 +1,51 @@
+package de.c4t4lysm.catamines.utils.menusystem;
+
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.Utils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class Menu implements InventoryHolder {
+
+    protected Inventory inventory;
+    protected PlayerMenuUtility playerMenuUtility;
+
+    public Menu(PlayerMenuUtility playerMenuUtility) {
+        this.playerMenuUtility = playerMenuUtility;
+    }
+
+    public abstract String getMenuName();
+
+    public abstract int getSlots();
+
+    public abstract void handleMenu(InventoryClickEvent event);
+
+    public abstract void setMenuItems();
+
+    public void open() {
+        inventory = Bukkit.createInventory(this, getSlots(), getMenuName());
+        this.setMenuItems();
+
+        playerMenuUtility.getOwner().openInventory(inventory);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    public void setFillerGlass() {
+        for (int i = 0; i < getSlots(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, ItemStackBuilder.buildItem(Material.GRAY_STAINED_GLASS_PANE, " "));
+            }
+        }
+    }
+
+    public void updateMenus() {
+        Utils.updateMenus();
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/PaginatedMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/PaginatedMenu.java
@@ -1,0 +1,56 @@
+package de.c4t4lysm.catamines.utils.menusystem;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public abstract class PaginatedMenu extends Menu {
+
+    protected int page = 0;
+    protected int maxItemsPerPage = 21;
+    protected int index = 0;
+
+    public PaginatedMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+    }
+
+    public void addMenuBorder() {
+
+        CataMines plugin = CataMines.getInstance();
+
+        ItemStack fillerGlass = ItemStackBuilder.buildItem(Material.GRAY_STAINED_GLASS_PANE, " ");
+
+        inventory.setItem(48, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Previous-Page.Name"), plugin.getLangStringList("GUI.Universal.Previous-Page.Lore")));
+
+        inventory.setItem(49, ItemStackBuilder.buildItem(Material.BARRIER, plugin.getLangString("GUI.Universal.Close.Name"), plugin.getLangStringList("GUI.Universal.Close.Lore")));
+
+        inventory.setItem(50, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Next-Page.Name"), plugin.getLangStringList("GUI.Universal.Next-Page.Lore")));
+
+        for (int i = 0; i < 10; i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, fillerGlass.clone());
+            }
+        }
+
+        inventory.setItem(17, fillerGlass.clone());
+        inventory.setItem(18, fillerGlass.clone());
+        inventory.setItem(26, fillerGlass.clone());
+        inventory.setItem(27, fillerGlass.clone());
+        inventory.setItem(35, fillerGlass.clone());
+        inventory.setItem(36, fillerGlass.clone());
+
+        for (int i = 44; i < 54; i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, fillerGlass.clone());
+            }
+        }
+
+    }
+
+    public int getMaxItemsPerPage() {
+        return maxItemsPerPage;
+    }
+
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/PlayerMenuUtility.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/PlayerMenuUtility.java
@@ -1,0 +1,70 @@
+package de.c4t4lysm.catamines.utils.menusystem;
+
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineLootItem;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.entity.Player;
+
+public class PlayerMenuUtility {
+
+    private Player owner;
+
+    private CuboidCataMine cuboidCataMine;
+    private CataMineBlock block;
+    private CataMineLootItem item;
+
+    private Menu menu;
+    private int mineListMenuPage;
+
+    public PlayerMenuUtility(Player owner) {
+        this.owner = owner;
+    }
+
+    public Player getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Player owner) {
+        this.owner = owner;
+    }
+
+    public CuboidCataMine getMine() {
+        return cuboidCataMine;
+    }
+
+    public void setMine(CuboidCataMine cuboidCataMine) {
+        this.cuboidCataMine = cuboidCataMine;
+    }
+
+    public CataMineBlock getBlock() {
+        return block;
+    }
+
+    public void setBlock(CataMineBlock block) {
+        this.block = block;
+    }
+
+    public Menu getMenu() {
+        return menu;
+    }
+
+    public void setMenu(Menu menu) {
+        this.menu = menu;
+    }
+
+    public int getMineListMenuPage() {
+        return mineListMenuPage;
+    }
+
+    public void setMineListMenuPage(int mineListMenuPage) {
+        this.mineListMenuPage = mineListMenuPage;
+    }
+
+    public CataMineLootItem getItem() {
+        return item;
+    }
+
+    public void setItem(CataMineLootItem item) {
+        this.item = item;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menulisteners/MenuListener.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menulisteners/MenuListener.java
@@ -1,0 +1,26 @@
+package de.c4t4lysm.catamines.utils.menusystem.menulisteners;
+
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.InventoryHolder;
+
+public class MenuListener implements Listener {
+
+    @EventHandler
+    public void onMenuClick(InventoryClickEvent event) {
+
+        InventoryHolder holder = event.getInventory().getHolder();
+
+        if (holder instanceof Menu) {
+
+            Menu menu = (Menu) holder;
+
+            menu.handleMenu(event);
+        }
+
+    }
+
+
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/MineListMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/MineListMenu.java
@@ -1,0 +1,151 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.PaginatedMenu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+public class MineListMenu extends PaginatedMenu {
+
+    public MineListMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+    }
+
+    public MineListMenu(PlayerMenuUtility playerMenuUtility, int page) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.page = page;
+    }
+
+    @Override
+    public String getMenuName() {
+        return CataMines.getInstance().getLangString("GUI.Mine-List-Menu.Title");
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || itemStack.getType().equals(Material.GRAY_STAINED_GLASS_PANE) || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        if (itemStack.getItemMeta() == null) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+        List<CuboidCataMine> cuboidCataMines = MineManager.getInstance().getMines();
+
+        if (event.getCurrentItem().getType() != Material.AIR && !event.getCurrentItem().getType().equals(Material.GRAY_STAINED_GLASS_PANE)) {
+
+            switch (event.getRawSlot()) {
+                case 48:
+                    if (page == 0) {
+                        player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.First-Page"));
+                    } else {
+                        page = page - 1;
+                        playerMenuUtility.setMineListMenuPage(playerMenuUtility.getMineListMenuPage() - 1);
+                        super.open();
+                        player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                    }
+                    break;
+                case 49:
+                    player.closeInventory();
+                    player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                    break;
+                case 50:
+                    if (!((index + 1) >= cuboidCataMines.size())) {
+                        page = page + 1;
+                        playerMenuUtility.setMineListMenuPage(playerMenuUtility.getMineListMenuPage() + 1);
+                        super.open();
+                        player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                    } else {
+                        player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Last-Page"));
+                    }
+                    break;
+                default:
+                    if (MineManager.getInstance().getMine(ChatColor.stripColor(event.getCurrentItem().getItemMeta().getDisplayName())) != null) {
+                        new MineMenu(playerMenuUtility, MineManager.getInstance().getMine(ChatColor.stripColor(event.getCurrentItem().getItemMeta().getDisplayName()))).open();
+                        player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                    } else {
+                        player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Mine-Doesnt-Exist"));
+                    }
+            }
+
+        }
+
+    }
+
+    @Override
+    public void setMenuItems() {
+        addMenuBorder();
+
+        List<CuboidCataMine> cuboidCataMines = MineManager.getInstance().getMines();
+
+        if (cuboidCataMines != null && !cuboidCataMines.isEmpty()) {
+            for (int i = 0; i < getMaxItemsPerPage(); i++) {
+                index = getMaxItemsPerPage() * page + i;
+                if (index >= cuboidCataMines.size()) break;
+                if (cuboidCataMines.get(index) != null) {
+                    CuboidCataMine cuboidCataMine = cuboidCataMines.get(index);
+
+                    Material material = Material.STICK;
+                    CataMineBlock cataBlock;
+                    if (!cuboidCataMine.getBlocks().isEmpty()) {
+                        cataBlock = cuboidCataMine.getBlocks().stream().max(Comparator.comparingDouble(CataMineBlock::getChance)).get();
+                        material = cataBlock.getBlockData().getMaterial();
+                    }
+
+                    if (!material.isSolid()) {
+                        material = Material.WRITTEN_BOOK;
+                    }
+
+                    ArrayList<String> lore = new ArrayList<>();
+                    lore.add("");
+                    lore.add(ChatColor.AQUA + "Composition:");
+                    int miniIndex = 1;
+                    for (CataMineBlock block : cuboidCataMine.getBlocks()) {
+                        lore.add(ChatColor.RED + "  " + miniIndex + ". " + ChatColor.GOLD + block.getBlockData().getMaterial() + ": " + ChatColor.RED + block.getChance() + "%");
+                        miniIndex++;
+                    }
+                    lore.add(ChatColor.AQUA + "Delay: " + ChatColor.RED + cuboidCataMine.getResetDelay());
+                    lore.add(ChatColor.AQUA + "Reset percentage: " + ChatColor.RED + cuboidCataMine.getResetPercentage() + "%");
+                    lore.add(ChatColor.AQUA + "Reset mode: " + ChatColor.RED + cuboidCataMine.getResetMode().name());
+                    lore.add(ChatColor.AQUA + "Replace mode: " + ChatColor.RED + cuboidCataMine.isReplaceMode());
+                    lore.add(ChatColor.AQUA + "Warns: " + ChatColor.RED + cuboidCataMine.isWarn());
+                    lore.add(ChatColor.AQUA + "  Warns hotbar: " + ChatColor.RED + cuboidCataMine.isWarnHotbar());
+                    lore.add(ChatColor.AQUA + "  Warns globally: " + ChatColor.RED + cuboidCataMine.isWarnGlobal());
+                    String warnSeconds = cuboidCataMine.getWarnSeconds().toString();
+                    lore.add(ChatColor.AQUA + "  Warn seconds: " + ChatColor.RED + warnSeconds.substring(1, warnSeconds.length() - 1));
+                    lore.add(ChatColor.AQUA + "  Warn distance: " + ChatColor.RED + cuboidCataMine.getWarnDistance());
+                    lore.add(ChatColor.AQUA + "Is stopped: " + ChatColor.RED + cuboidCataMine.isStopped());
+
+                    ItemStack mineItem = ItemStackBuilder.buildItem(material, !cuboidCataMine.isStopped() && cuboidCataMine.isRunnable() ? ChatColor.GREEN + cuboidCataMine.getName() : ChatColor.RED + cuboidCataMine.getName(), lore);
+
+                    inventory.addItem(mineItem);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/MineMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/MineMenu.java
@@ -1,0 +1,236 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.*;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.CompositionMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class MineMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin = CataMines.getInstance();
+
+    public MineMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.mine = playerMenuUtility.getMine();
+    }
+
+    public MineMenu(PlayerMenuUtility playerMenuUtility, CuboidCataMine mine) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        playerMenuUtility.setMine(mine);
+        this.mine = mine;
+    }
+
+    @Override
+    public String getMenuName() {
+        return CataMines.getInstance().getLangString("GUI.Mine-Menu.Title").replaceAll("%mine%", mine.getName());
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+
+        switch (event.getRawSlot()) {
+            case 10:
+                new CompositionMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+            case 12:
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                if (!event.isRightClick()) {
+                    switch (mine.getResetMode()) {
+                        case TIME:
+                        case TIME_PERCENTAGE:
+                            new ResetDelayMenu(playerMenuUtility).open();
+                            break;
+                        case PERCENTAGE:
+                            new ResetPercentageMenu(playerMenuUtility).open();
+                    }
+                } else {
+                    mine.setResetMode(mine.getResetMode().next());
+                    mine.save();
+                    updateMenus();
+                }
+                break;
+            case 14:
+                new FlagsMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+            case 16:
+                new PickaxeEfficiencyMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+            case 28:
+                player.performCommand("cm reset " + mine.getName());
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+            case 30:
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                mine.setResetMode(mine.getResetMode().next());
+                mine.save();
+                updateMenus();
+                break;
+            case 32:
+                player.closeInventory();
+                if (mine.getTeleportLocation() == null) {
+                    player.sendMessage(CataMines.PREFIX + plugin.getLangString("Error-Messages.Mine.Teleport-Error").replaceAll("%mine%", mine.getName()));
+                    return;
+                }
+                player.teleport(mine.getTeleportLocation());
+                player.playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, 0.3F, 1F);
+                break;
+            case 34:
+                new DeleteConfirmMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+            case 45:
+                if (mine.getRegion() == null) {
+                    player.sendMessage(CataMines.PREFIX + plugin.getLangString("Error-Messages.Mine.Invalid-Region"));
+                    break;
+                }
+                mine.setStopped(!mine.isStopped());
+                mine.save();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                updateMenus();
+                break;
+            case 49:
+                new MineListMenu(playerMenuUtility, playerMenuUtility.getMineListMenuPage()).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+        }
+
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        // ItemStack for configuring the composition
+        List<String> compLore = plugin.getLangStringList("GUI.Mine-Menu.Items.Configure-Composition.Lore");
+        compLore.replaceAll(s -> s.replaceAll("%chance%", String.valueOf(mine.getCompositionChance())));
+        inventory.setItem(10, ItemStackBuilder.buildItem(Material.STONE, plugin.getLangString("GUI.Mine-Menu.Items.Configure-Composition.Name"), compLore));
+
+        Material item = Material.BARRIER;
+        String itemname = "";
+        List<String> lore = null;
+
+        switch (mine.getResetMode()) {
+            case TIME:
+                item = Material.CLOCK;
+                itemname = plugin.getLangString("GUI.Mine-Menu.Items.Configure-Delay.Name");
+                lore = plugin.getLangStringList("GUI.Mine-Menu.Items.Configure-Delay.Lore");
+                break;
+            case PERCENTAGE:
+                item = Material.STONE_PICKAXE;
+                itemname = plugin.getLangString("GUI.Mine-Menu.Items.Configure-Percentage.Name");
+                lore = plugin.getLangStringList("GUI.Mine-Menu.Items.Configure-Percentage.Lore");
+                break;
+            case TIME_PERCENTAGE:
+                item = Material.COMPARATOR;
+                itemname = plugin.getLangString("GUI.Mine-Menu.Items.Configure-TimePercentage.Name");
+                lore = plugin.getLangStringList("GUI.Mine-Menu.Items.Configure-TimePercentage.Lore");
+        }
+
+        lore.replaceAll(s -> s.replaceAll("%delay%", String.valueOf(mine.getResetDelay())).replaceAll("%percentage%", String.valueOf(mine.getResetPercentage())));
+        inventory.setItem(12, ItemStackBuilder.buildItem(item, itemname, lore));
+
+        // Flag menu
+        List<String> flagLore = plugin.getLangStringList("GUI.Mine-Menu.Items.Flag-Menu.Lore");
+        flagLore.replaceAll(s -> s.replaceAll("%warn%", String.valueOf(mine.isWarn()))
+                .replaceAll("%global%", String.valueOf(mine.isWarnGlobal()))
+                .replaceAll("%actionbar%", String.valueOf(mine.isWarnHotbar()))
+                .replaceAll("%teleports%", String.valueOf(mine.isTeleportPlayers()))
+                .replaceAll("%resettp%", String.valueOf(mine.isTeleportPlayersToResetLocation()))
+                .replaceAll("%replacemode%", String.valueOf(mine.isReplaceMode()))
+                .replaceAll("%warndistance%", String.valueOf(mine.getWarnDistance())));
+        inventory.setItem(14, ItemStackBuilder.buildItem(Material.TORCH, plugin.getLangString("GUI.Mine-Menu.Items.Flag-Menu.Name"), flagLore));
+
+        // ItemStack for configuring min. efficiency level
+        List<String> efficiencyLore = plugin.getLangStringList("GUI.Mine-Menu.Items.Efficiency-Lvl.Lore");
+        efficiencyLore.replaceAll(s -> s.replaceAll("%level%", String.valueOf(mine.getMinEfficiencyLvl())));
+        inventory.setItem(16, ItemStackBuilder.buildItem(Material.DIAMOND_PICKAXE, plugin.getLangString("GUI.Mine-Menu.Items.Efficiency-Lvl.Name"), efficiencyLore));
+
+        // Reset mine
+        inventory.setItem(28, ItemStackBuilder.buildItem(Material.REDSTONE, plugin.getLangString("GUI.Mine-Menu.Items.Reset-Mine.Name")));
+
+        // Reset mode cycle button
+        Material resetModeIcon;
+        String resetModeName;
+        switch (mine.getResetMode()) {
+            case TIME:
+                resetModeIcon = Material.CLOCK;
+                resetModeName = plugin.getLangString("GUI.Mine-Menu.Items.Reset-Mode.Time.Name");
+                break;
+            case PERCENTAGE:
+                resetModeIcon = Material.STONE_PICKAXE;
+                resetModeName = plugin.getLangString("GUI.Mine-Menu.Items.Reset-Mode.Percentage.Name");
+                break;
+            default: // TIME_PERCENTAGE
+                resetModeIcon = Material.COMPARATOR;
+                resetModeName = plugin.getLangString("GUI.Mine-Menu.Items.Reset-Mode.Both.Name");
+                break;
+        }
+        List<String> resetModeLore = plugin.getLangStringList("GUI.Mine-Menu.Items.Reset-Mode.Lore");
+        inventory.setItem(30, ItemStackBuilder.buildItem(resetModeIcon, resetModeName, resetModeLore));
+
+        // Teleport to mine
+        inventory.setItem(32, ItemStackBuilder.buildItem(Material.ENDER_PEARL, plugin.getLangString("GUI.Mine-Menu.Items.Teleport.Name"), plugin.getLangStringList("GUI.Mine-Menu.Items.Teleport.Lore")));
+        // Delete mine
+        inventory.setItem(34, ItemStackBuilder.buildItem(Material.REDSTONE_BLOCK, plugin.getLangString("GUI.Mine-Menu.Items.Delete.Name")));
+
+        // De-/Activate
+        inventory.setItem(45, ItemStackBuilder.buildItem(!mine.isStopped() ? Material.REDSTONE_TORCH : Material.LEVER, !mine.isStopped() ? plugin.getLangString("GUI.Mine-Menu.Items.Start-Stop.Active.Name") : ChatColor.GRAY + plugin.getLangString("GUI.Mine-Menu.Items.Start-Stop.Inactive.Name"), plugin.getLangStringList("GUI.Mine-Menu.Items.Start-Stop.Lore")));
+
+        // Go back to mine list
+        inventory.setItem(49, ItemStackBuilder.buildItem(Material.BARRIER, plugin.getLangString("GUI.Mine-Menu.Items.Back.Name"), plugin.getLangStringList("GUI.Mine-Menu.Items.Back.Lore")));
+
+        // Displays if the mine could run
+        if (mine.checkRunnable() && !mine.isStopped()) {
+            inventory.setItem(53, ItemStackBuilder.buildItem(Material.LIME_DYE, plugin.getLangString("GUI.Mine-Menu.Items.Running.Active.Name"), plugin.getLangStringList("GUI.Mine-Menu.Items.Running.Active.Lore")));
+        } else {
+
+            ArrayList<String> reasons = new ArrayList<>();
+
+            if (mine.getRegion() == null) {
+                reasons.add(plugin.getLangString("GUI.Mine-Menu.Items.Running.Inactive.Reasons.Invalid-Region"));
+            }
+            if (mine.isStopped()) {
+                reasons.add(plugin.getLangString("GUI.Mine-Menu.Items.Running.Inactive.Reasons.Stopped"));
+            }
+            if (mine.getRandomPattern() == null) {
+                reasons.add(plugin.getLangString("GUI.Mine-Menu.Items.Running.Inactive.Reasons.No-Composition"));
+            }
+            if (!(mine.getResetDelay() > 0 && mine.getResetDelay() <= 100000)) {
+                reasons.add(plugin.getLangString("GUI.Mine-Menu.Items.Running.Inactive.Reasons.Invalid-Delay").replaceAll("%delay%", String.valueOf(mine.getResetDelay())));
+            }
+
+            inventory.setItem(53, ItemStackBuilder.buildItem(Material.GRAY_DYE, plugin.getLangString("GUI.Mine-Menu.Items.Running.Inactive.Name"), reasons));
+        }
+
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/DeleteConfirmMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/DeleteConfirmMenu.java
@@ -1,0 +1,71 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineListMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+public class DeleteConfirmMenu extends Menu {
+
+    private final CuboidCataMine cuboidCataMine;
+
+    public DeleteConfirmMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        this.cuboidCataMine = playerMenuUtility.getMine();
+    }
+
+    @Override
+    public String getMenuName() {
+        return ChatColor.DARK_RED + "Delete Mine?";
+    }
+
+    @Override
+    public int getSlots() {
+        return 9;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+
+        switch (event.getRawSlot()) {
+            case 0:
+                CataMines.removePlayerMenuUtility(player);
+                player.performCommand("cm delete " + cuboidCataMine.getName());
+                new MineListMenu(CataMines.getPlayerMenuUtility(player)).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                updateMenus();
+                break;
+            case 8:
+                new MineMenu(playerMenuUtility, playerMenuUtility.getMine()).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                break;
+        }
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        inventory.setItem(0, ItemStackBuilder.buildItem(Material.GREEN_STAINED_GLASS_PANE, ChatColor.GREEN + "" + ChatColor.BOLD + "CONFIRM", "", ChatColor.RED + "Permanently deletes this mine"));
+        inventory.setItem(8, ItemStackBuilder.buildItem(Material.RED_STAINED_GLASS_PANE, ChatColor.DARK_RED + "" + ChatColor.BOLD + "CANCEL", "", ChatColor.GREEN + "Cancels the process"));
+
+        setFillerGlass();
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/FlagsMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/FlagsMenu.java
@@ -1,0 +1,167 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+import java.util.List;
+
+public class FlagsMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin;
+
+    public FlagsMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        mine = playerMenuUtility.getMine();
+        plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Flags-Menu.Title");
+    }
+
+    @Override
+    public int getSlots() {
+        return 45;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player p = (Player) event.getWhoClicked();
+        switch (event.getRawSlot()) {
+            case 19:
+                mine.setWarn(!mine.isWarn());
+                break;
+            case 10:
+                mine.setWarnGlobal(!mine.isWarnGlobal());
+                break;
+            case 28:
+                mine.setWarnHotbar(!mine.isWarnHotbar());
+                break;
+            case 21:
+                mine.setTeleportPlayers(!mine.isTeleportPlayers());
+                break;
+            case 30:
+                mine.setTeleportPlayersToResetLocation(!mine.isTeleportPlayersToResetLocation());
+                break;
+            case 23:
+                mine.setReplaceMode(!mine.isReplaceMode());
+                break;
+            case 25:
+                new WarnDistanceMenu(playerMenuUtility).open();
+                p.playSound(p.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 36:
+                new MineMenu(playerMenuUtility).open();
+                p.playSound(p.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+        }
+
+        mine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        // Enable warn
+        if (mine.isWarn()) {
+            inventory.setItem(19, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn.Active.Lore")));
+        } else {
+            inventory.setItem(19, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn.Inactive.Lore")));
+        }
+
+        // Warn globally
+        if (mine.isWarnGlobal()) {
+            inventory.setItem(10, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn-Global.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn-Global.Active.Lore")));
+        } else {
+            inventory.setItem(10, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn-Global.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn-Global.Inactive.Lore")));
+        }
+
+        // Action bar
+        if (mine.isWarnHotbar()) {
+            inventory.setItem(28, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn-Hotbar.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn-Hotbar.Active.Lore")));
+        } else {
+            inventory.setItem(28, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Warn-Hotbar.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Warn-Hotbar.Inactive.Lore")));
+        }
+
+        // Teleport players
+        if (mine.isTeleportPlayers()) {
+            inventory.setItem(21, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Teleport-Players.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Teleport-Players.Active.Lore")));
+        } else {
+            inventory.setItem(21, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Teleport-Players.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Teleport-Players.Inactive.Lore")));
+        }
+
+        // Teleport players to reset location
+        if (mine.isTeleportPlayersToResetLocation()) {
+            inventory.setItem(30, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Teleport-Players-To-Reset-Location.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Teleport-Players-To-Reset-Location.Active.Lore")));
+        } else {
+            inventory.setItem(30, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Teleport-Players-To-Reset-Location.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Teleport-Players-To-Reset-Location.Inactive.Lore")));
+        }
+
+        // Replace mode
+        if (mine.isReplaceMode()) {
+            inventory.setItem(23, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Replace-Mode.Active.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Replace-Mode.Active.Lore")));
+        } else {
+            inventory.setItem(23, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    plugin.getLangString("GUI.Flags-Menu.Items.Replace-Mode.Inactive.Name"),
+                    plugin.getLangStringList("GUI.Flags-Menu.Items.Replace-Mode.Inactive.Lore")));
+        }
+
+        // Warn distance
+        List<String> warnDistanceLore = plugin.getLangStringList("GUI.Flags-Menu.Items.Warn-Distance.Lore");
+        warnDistanceLore.replaceAll(s -> s.replaceAll("%distance%", String.valueOf(mine.getWarnDistance())));
+        inventory.setItem(25, ItemStackBuilder.buildItem(Material.STICK, plugin.getLangString("GUI.Flags-Menu.Items.Warn-Distance.Name"), warnDistanceLore));
+
+        // Back arrow
+        inventory.setItem(36, ItemStackBuilder.buildItem(
+                Material.ARROW,
+                plugin.getLangString("GUI.Universal.Back-To-Mine-Menu.Name"),
+                plugin.getLangStringList("GUI.Universal.Back-To-Mine-Menu.Lore")));
+
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/PickaxeEfficiencyMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/PickaxeEfficiencyMenu.java
@@ -1,0 +1,106 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Objects;
+
+public class PickaxeEfficiencyMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin;
+
+    public PickaxeEfficiencyMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        mine = playerMenuUtility.getMine();
+        this.plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Efficiency-Menu.Title").replaceAll("%level%", String.valueOf(mine.getMinEfficiencyLvl()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        int addLevel = 0;
+
+        switch (event.getRawSlot()) {
+            case 45:
+                new MineMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 3 * 9 - 6:
+                addLevel = 1;
+                break;
+            case 4 * 9 - 6:
+                addLevel = 5;
+                break;
+            case 5 * 9 - 6:
+                addLevel = 10;
+                break;
+            case 3 * 9 - 4:
+                addLevel = -1;
+                break;
+            case 4 * 9 - 4:
+                addLevel = -5;
+                break;
+            case 5 * 9 - 4:
+                addLevel = -10;
+                break;
+        }
+
+        if (addLevel == 0) {
+            return;
+        }
+
+        mine.setMinEfficiencyLvl(mine.getMinEfficiencyLvl() + addLevel);
+        mine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+        List<String> efficiencyLore = plugin.getLangStringList("GUI.Efficiency-Menu.Items.Current-Level.Lore");
+        efficiencyLore.replaceAll(s -> s.replaceAll("%level%", String.valueOf(mine.getMinEfficiencyLvl())));
+        inventory.setItem(13, ItemStackBuilder.buildItem(Material.DIAMOND_PICKAXE, plugin.getLangString("GUI.Efficiency-Menu.Items.Current-Level.Name").replaceAll("%level%", String.valueOf(mine.getMinEfficiencyLvl())),
+                efficiencyLore));
+
+        String increaseBy = plugin.getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = plugin.getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Back-To-Mine-Menu.Name"), plugin.getLangStringList("GUI.Universal.Back-To-Mine-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/ResetDelayMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/ResetDelayMenu.java
@@ -1,0 +1,112 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+public class ResetDelayMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin;
+
+    public ResetDelayMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        mine = playerMenuUtility.getMine();
+        this.plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Reset-Delay-Menu.Title").replaceAll("%delay%", String.valueOf(mine.getResetDelay()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        int addResetDelay = 0;
+
+        switch (event.getRawSlot()) {
+            case 45:
+                new MineMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 6:
+                new ResetPercentageMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 3 * 9 - 6:
+                addResetDelay = 1;
+                break;
+            case 4 * 9 - 6:
+                addResetDelay = 5;
+                break;
+            case 5 * 9 - 6:
+                addResetDelay = 10;
+                break;
+            case 3 * 9 - 4:
+                addResetDelay = -1;
+                break;
+            case 4 * 9 - 4:
+                addResetDelay = -5;
+                break;
+            case 5 * 9 - 4:
+                addResetDelay = -10;
+                break;
+        }
+
+        if (addResetDelay == 0) {
+            return;
+        }
+
+        mine.setResetDelay(mine.getResetDelay() + addResetDelay);
+        if (mine.getResetDelay() < mine.getCountdown()) {
+            mine.setCountdown(mine.getResetDelay());
+        }
+        mine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        inventory.setItem(13, ItemStackBuilder.buildItem(Material.CLOCK, plugin.getLangString("GUI.Reset-Delay-Menu.Items.Current-Delay.Name").replaceAll("%delay%", String.valueOf(mine.getResetDelay()))));
+
+        inventory.setItem(6, ItemStackBuilder.buildItem(Material.LEVER, plugin.getLangString("GUI.Reset-Delay-Menu.Items.Switch.Name"), plugin.getLangStringList("GUI.Reset-Delay-Menu.Items.Switch.Lore")));
+
+        String increaseBy = plugin.getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = plugin.getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Back-To-Mine-Menu.Name"), plugin.getLangStringList("GUI.Universal.Back-To-Mine-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/ResetPercentageMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/ResetPercentageMenu.java
@@ -1,0 +1,152 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+import java.util.Objects;
+
+public class ResetPercentageMenu extends Menu {
+
+    private final CataMines plugin;
+    private final CuboidCataMine mine;
+
+    public ResetPercentageMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.plugin = CataMines.getInstance();
+        this.mine = playerMenuUtility.getMine();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Reset-Percentage-Menu.Title").replaceAll("%percentage%", String.valueOf(mine.getResetPercentage()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        if (event.getCurrentItem() == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        double addResetPercentage = 0;
+        switch (event.getRawSlot()) {
+            case 45:
+                new MineMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 6:
+                new ResetDelayMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 3 * 9 - 8:
+                addResetPercentage = 0.01;
+                break;
+            case 3 * 9 - 7:
+            case 5 * 9 - 8:
+                addResetPercentage = 0.1;
+                break;
+            case 3 * 9 - 6:
+            case 5 * 9 - 7:
+                addResetPercentage = 1;
+                break;
+            case 4 * 9 - 8:
+                addResetPercentage = 0.05;
+                break;
+            case 4 * 9 - 7:
+                addResetPercentage = 0.5;
+                break;
+            case 4 * 9 - 6:
+                addResetPercentage = 5;
+                break;
+            case 5 * 9 - 6:
+                addResetPercentage = 10;
+                break;
+            case 3 * 9 - 4:
+            case 5 * 9 - 3:
+                addResetPercentage = -1;
+                break;
+            case 3 * 9 - 3:
+            case 5 * 9 - 2:
+                addResetPercentage = -0.1;
+                break;
+            case 3 * 9 - 2:
+                addResetPercentage = -0.01;
+                break;
+            case 4 * 9 - 4:
+                addResetPercentage = -5;
+                break;
+            case 4 * 9 - 3:
+                addResetPercentage = -0.5;
+                break;
+            case 4 * 9 - 2:
+                addResetPercentage = -0.05;
+                break;
+            case 5 * 9 - 4:
+                addResetPercentage = -10;
+                break;
+        }
+
+        if (addResetPercentage == 0) {
+            return;
+        }
+
+        mine.setResetPercentage(mine.getResetPercentage() + addResetPercentage);
+        mine.save();
+        updateMenus();
+
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        inventory.setItem(13, ItemStackBuilder.buildItem(Material.STONE_PICKAXE, plugin.getLangString("GUI.Reset-Percentage-Menu.Items.Current-Percentage.Name").replaceAll("%delay%", String.valueOf(mine.getResetPercentage()))));
+
+        inventory.setItem(6, ItemStackBuilder.buildItem(Material.LEVER, plugin.getLangString("GUI.Reset-Percentage-Menu.Items.Switch.Name"), plugin.getLangStringList("GUI.Reset-Percentage-Menu.Items.Switch.Lore")));
+
+
+        String increaseBy = plugin.getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = plugin.getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.01")));
+        inventory.setItem(3 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+
+        inventory.setItem(4 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.05")));
+        inventory.setItem(4 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+
+        inventory.setItem(5 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(5 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(3 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.01")));
+
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(4 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.05")));
+
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+        inventory.setItem(5 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Back-To-Mine-Menu.Name"), plugin.getLangStringList("GUI.Universal.Back-To-Mine-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/WarnDistanceMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/WarnDistanceMenu.java
@@ -1,0 +1,101 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+public class WarnDistanceMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin;
+
+    public WarnDistanceMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.mine = playerMenuUtility.getMine();
+        this.plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Warn-Distance-Menu.Title").replaceAll("%distance%", String.valueOf(mine.getWarnDistance()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        int addWarnDistance = 0;
+
+        switch (event.getRawSlot()) {
+            case 45:
+                new FlagsMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 3 * 9 - 6:
+                addWarnDistance = 1;
+                break;
+            case 4 * 9 - 6:
+                addWarnDistance = 5;
+                break;
+            case 5 * 9 - 6:
+                addWarnDistance = 10;
+                break;
+            case 3 * 9 - 4:
+                addWarnDistance = -1;
+                break;
+            case 4 * 9 - 4:
+                addWarnDistance = -5;
+                break;
+            case 5 * 9 - 4:
+                addWarnDistance = -10;
+                break;
+        }
+
+        if (addWarnDistance == 0) {
+            return;
+        }
+
+        mine.setWarnDistance(mine.getWarnDistance() + addWarnDistance);
+        mine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+        inventory.setItem(13, ItemStackBuilder.buildItem(Material.STICK, plugin.getLangString("GUI.Warn-Distance-Menu.Items.Current-Distance.Name").replaceAll("%distance%", String.valueOf(mine.getWarnDistance()))));
+
+        String increaseBy = plugin.getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = plugin.getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Back-To-Mine-Menu.Name"), plugin.getLangStringList("GUI.Universal.Back-To-Mine-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/CompositionBlockMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/CompositionBlockMenu.java
@@ -1,0 +1,195 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable.ChangeBlockLootTableMenu;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable.LootItemListMenu;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Objects;
+
+public class CompositionBlockMenu extends Menu {
+
+    private final CuboidCataMine cuboidCataMine;
+    private final CataMineBlock block;
+    private final CataMines plugin;
+
+    public CompositionBlockMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        cuboidCataMine = playerMenuUtility.getMine();
+        this.block = playerMenuUtility.getBlock();
+        this.plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Composition-Block-Menu.Title").replaceAll("%blockChance%", String.valueOf(block.getChance())).replaceAll("%compChance%", String.valueOf(cuboidCataMine.getCompositionChance()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        event.setCancelled(true);
+        ItemStack itemStack = event.getCurrentItem();
+        if (itemStack == null || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory())) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+
+        double addPercentage = 0;
+
+        switch (event.getRawSlot()) {
+            case 6:
+                new ChangeBlockLootTableMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 7:
+                block.setAddLootTable(!block.isAddLootTable());
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                cuboidCataMine.save();
+                updateMenus();
+                return;
+            case 8:
+                new LootItemListMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 45:
+                new CompositionMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 3 * 9 - 8:
+                addPercentage = 0.01;
+                break;
+            case 3 * 9 - 7:
+            case 5 * 9 - 8:
+                addPercentage = 0.1;
+                break;
+            case 3 * 9 - 6:
+            case 5 * 9 - 7:
+                addPercentage = 1;
+                break;
+            case 4 * 9 - 8:
+                addPercentage = 0.05;
+                break;
+            case 4 * 9 - 7:
+                addPercentage = 0.5;
+                break;
+            case 4 * 9 - 6:
+                addPercentage = 5;
+                break;
+            case 5 * 9 - 6:
+                addPercentage = 10;
+                break;
+            case 3 * 9 - 4:
+            case 5 * 9 - 3:
+                addPercentage = -1;
+                break;
+            case 3 * 9 - 3:
+            case 5 * 9 - 2:
+                addPercentage = -0.1;
+                break;
+            case 3 * 9 - 2:
+                addPercentage = -0.01;
+                break;
+            case 4 * 9 - 4:
+                addPercentage = -5;
+                break;
+            case 4 * 9 - 3:
+                addPercentage = -0.5;
+                break;
+            case 4 * 9 - 2:
+                addPercentage = -0.05;
+                break;
+            case 5 * 9 - 4:
+                addPercentage = -10;
+                break;
+        }
+
+        if (addPercentage == 0) {
+            return;
+        }
+
+        try {
+            cuboidCataMine.setBlockChance(block, block.getChance() + addPercentage);
+        } catch (IllegalArgumentException exception) {
+            player.sendMessage(CataMines.PREFIX + exception.getMessage());
+        }
+
+        cuboidCataMine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        inventory.setItem(6, ItemStackBuilder.buildItem(Material.DROPPER, plugin.getLangString("GUI.Composition-Block-Menu.Items.Change-Table.Name")));
+        inventory.setItem(7, ItemStackBuilder.buildItem(block.isAddLootTable() ? Material.LIME_DYE : Material.GRAY_DYE,
+                block.isAddLootTable() ?
+                        plugin.getLangString("GUI.Composition-Block-Menu.Items.Add-Loot-Table.Active.Name") :
+                        plugin.getLangString("GUI.Composition-Block-Menu.Items.Add-Loot-Table.Inactive.Name"),
+                block.isAddLootTable() ?
+                        plugin.getLangStringList("GUI.Composition-Block-Menu.Items.Add-Loot-Table.Active.Lore") :
+                        plugin.getLangStringList("GUI.Composition-Block-Menu.Items.Add-Loot-Table.Inactive.Lore")));
+        inventory.setItem(8, ItemStackBuilder.buildItem(Material.DISPENSER, plugin.getLangString("GUI.Composition-Block-Menu.Items.Configure-Table.Name")));
+
+        BlockData blockData = block.getBlockData();
+        List<String> blockLore = plugin.getLangStringList("GUI.Composition-Block-Menu.Items.Current-Block.Lore");
+        blockLore.replaceAll(s -> s.replaceAll("%blockChance%", String.valueOf(block.getChance()))
+                .replaceAll("%compChance%", String.valueOf(cuboidCataMine.getCompositionChance()))
+                .replaceAll("%blockdata%", blockData.getAsString(true).substring(10 + blockData.getMaterial().name().length())));
+
+        Material material = block.getBlockData().getMaterial();
+        if (!material.isItem()) {
+            material = Material.WRITTEN_BOOK;
+        }
+
+        inventory.setItem(13, ItemStackBuilder.buildItem(material, !material.isSolid() ? ChatColor.WHITE + block.getBlockData().getMaterial().toString() : "",
+                blockLore));
+
+        String increaseBy = plugin.getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = plugin.getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.01")));
+        inventory.setItem(3 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+
+        inventory.setItem(4 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.05")));
+        inventory.setItem(4 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+
+        inventory.setItem(5 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(5 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(3 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.01")));
+
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(4 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.05")));
+
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+        inventory.setItem(5 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, plugin.getLangString("GUI.Universal.Back-To-Block-Menu.Name"), plugin.getLangStringList("GUI.Universal.Back-To-Block-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/CompositionMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/CompositionMenu.java
@@ -1,0 +1,149 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.PaginatedMenu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.MineMenu;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompositionMenu extends PaginatedMenu {
+
+    private final CuboidCataMine mine;
+    private final CataMines plugin;
+
+    public CompositionMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        mine = playerMenuUtility.getMine();
+        plugin = CataMines.getInstance();
+    }
+
+    @Override
+    public String getMenuName() {
+        return plugin.getLangString("GUI.Composition-Menu.Title").replaceAll("%chance%", String.valueOf(mine.getCompositionChance()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (event.getCurrentItem() == null) {
+            return;
+        }
+
+        int slot = event.getRawSlot();
+        Player player = (Player) event.getWhoClicked();
+
+        switch (slot) {
+            case 49:
+                new MineMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 48:
+                if (page == 0) {
+                    player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.First-Page"));
+                } else {
+                    page = page - 1;
+                    super.open();
+                }
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 50:
+                if (!((index + 1) >= mine.getBlocks().size())) {
+                    page = page + 1;
+                    super.open();
+                } else {
+                    player.sendMessage(CataMines.PREFIX + CataMines.getInstance().getLangString("Error-Messages.GUI.Last-Page"));
+                }
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+        }
+
+        if (event.getClickedInventory() == player.getOpenInventory().getTopInventory()) {
+            if (!(slot >= 10 && slot <= 34) || (slot + 1) % 9 == 0 || slot % 9 == 0) return;
+
+            int row = slot / 9;
+            int index = getMaxItemsPerPage() * page + (slot - (8 + 2 * row));
+            if (event.isRightClick()) {
+                mine.removeBlock(index);
+                mine.save();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                updateMenus();
+            } else {
+                playerMenuUtility.setBlock(mine.getBlocks().get(index));
+                new CompositionBlockMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+            }
+            return;
+        }
+
+        Material mat = event.getCurrentItem().getType();
+        switch (mat) {
+            case WATER_BUCKET:
+                mat = Material.WATER;
+                break;
+            case LAVA_BUCKET:
+                mat = Material.LAVA;
+                break;
+        }
+
+        if (!mat.isBlock()) {
+            player.sendMessage(plugin.getLangString("Error-Messages.Mine.Material-Not-Solid"));
+            return;
+        }
+
+        BlockData blockData = mat.createBlockData();
+        mine.addBlock(new CataMineBlock(blockData, 0));
+        mine.save();
+        player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+        addMenuBorder();
+
+        ArrayList<CataMineBlock> blocks = new ArrayList<>(mine.getBlocks());
+
+        if (!blocks.isEmpty()) {
+            for (int i = 0; i < getMaxItemsPerPage(); i++) {
+                index = getMaxItemsPerPage() * page + i;
+                if (index >= blocks.size()) break;
+                if (blocks.get(index) != null) {
+
+                    CataMineBlock cataBlock = blocks.get(index);
+                    BlockData blockData = cataBlock.getBlockData();
+                    Material material = blockData.getMaterial();
+                    if (!material.isItem()) {
+                        material = Material.WRITTEN_BOOK;
+                    }
+
+                    List<String> lore = new ArrayList<>();
+                    plugin.getLangStringList("GUI.Composition-Menu.Items.Composition-Block.Lore")
+                            .forEach(s -> lore.add(s.replaceAll("%blockdata%", blockData.getAsString(true).substring(10 + blockData.getMaterial().name().length()))
+                                    .replaceAll("%chance%", String.valueOf(cataBlock.getChance()))));
+                    inventory.addItem(ItemStackBuilder.buildItem(material, material == Material.WRITTEN_BOOK ? ChatColor.WHITE + blockData.getMaterial().name() : "", lore));
+
+                }
+            }
+        }
+
+        inventory.setItem(53, ItemStackBuilder.buildItem(Material.SIGN, plugin.getLangString("GUI.Composition-Menu.Items.Info.Name"),
+                plugin.getLangStringList("GUI.Composition-Menu.Items.Info.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/ChangeBlockLootTableMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/ChangeBlockLootTableMenu.java
@@ -1,0 +1,86 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.CompositionBlockMenu;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineLootItem;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class ChangeBlockLootTableMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMineBlock block;
+
+    public ChangeBlockLootTableMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        this.mine = playerMenuUtility.getMine();
+        this.block = playerMenuUtility.getBlock();
+    }
+
+    @Override
+    public String getMenuName() {
+        return CataMines.getInstance().getLangString("GUI.Change-Loot-Table-Menu.Title");
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        if (event.getRawSlot() >= 45 && event.getRawSlot() <= 53) {
+            event.setCancelled(true);
+            if (event.getRawSlot() == 45) {
+                new CompositionBlockMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            }
+
+            if (event.getRawSlot() == 53) {
+                block.getLootTable().clear();
+                for (int i = 0; i < 45; i++) {
+                    if (event.getInventory().getItem(i) == null) {
+                        continue;
+                    }
+                    ItemStack itemStack = event.getInventory().getItem(i);
+                    block.getLootTable().add(new CataMineLootItem(itemStack));
+                }
+
+                mine.save();
+                event.getWhoClicked().sendMessage(CataMines.getInstance().getLangString("GUI.Change-Loot-Table-Menu.Items.Save-Table.Message"));
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                updateMenus();
+            }
+        }
+    }
+
+    @Override
+    public void setMenuItems() {
+
+        for (int i = 0; i < block.getLootTable().size(); i++) {
+            if (i >= 45) {
+                break;
+            }
+            inventory.setItem(i, block.getLootTable().get(i).getItem());
+        }
+
+        for (int i = 45; i < getSlots(); i++) {
+            inventory.setItem(i, ItemStackBuilder.buildItem(Material.GRAY_STAINED_GLASS_PANE, " "));
+        }
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, CataMines.getInstance().getLangString("GUI.Universal.Back-To-Block-Menu.Name"), CataMines.getInstance().getLangStringList("GUI.Universal.Back-To-Block-Menu.Lore")));
+
+        inventory.setItem(53, ItemStackBuilder.buildItem(Material.LIME_STAINED_GLASS, CataMines.getInstance().getLangString("GUI.Change-Loot-Table-Menu.Items.Save-Table.Name")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/LootItemListMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/LootItemListMenu.java
@@ -1,0 +1,84 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.CompositionBlockMenu;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineLootItem;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.Objects;
+
+public class LootItemListMenu extends Menu {
+
+    private final CataMineBlock block;
+
+    public LootItemListMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.block = playerMenuUtility.getBlock();
+    }
+
+    @Override
+    public String getMenuName() {
+        return ChatColor.AQUA + "Configure item drop chances";
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        int rawSlot = event.getRawSlot();
+        if (rawSlot >= 46 || Objects.equals(event.getClickedInventory(), event.getWhoClicked().getInventory()) || event.getCurrentItem() == null) {
+            return;
+        }
+
+        if (rawSlot == 45) {
+            new CompositionBlockMenu(playerMenuUtility).open();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+            return;
+        }
+
+        CataMineLootItem item = block.getLootTable().get(rawSlot);
+        playerMenuUtility.setItem(item);
+        new LootItemMenu(playerMenuUtility).open();
+        player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+    }
+
+    @Override
+    public void setMenuItems() {
+        for (int i = 0; i < block.getLootTable().size(); i++) {
+            if (i >= 45) break;
+            CataMineLootItem lootItem = block.getLootTable().get(i);
+            ItemStack itemStack = lootItem.getItem().clone();
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            List<String> itemLore = CataMines.getInstance().getLangStringList("GUI.Loot-Table-List-Menu.Items.Drop-Item.Lore");
+            itemLore.replaceAll(s -> s.replaceAll("%chance%", String.valueOf(lootItem.getChance())));
+            itemMeta.setLore(itemLore);
+            itemStack.setItemMeta(itemMeta);
+
+            inventory.setItem(i, itemStack);
+        }
+
+        for (int i = 45; i < getSlots(); i++) {
+            inventory.setItem(i, ItemStackBuilder.buildItem(Material.GRAY_STAINED_GLASS_PANE, " "));
+        }
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, CataMines.getInstance().getLangString("GUI.Universal.Back-To-Block-Menu.Name"), CataMines.getInstance().getLangStringList("GUI.Universal.Back-To-Block-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/LootItemMenu.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/menusystem/menus/minemenus/compositionmenu/blockloottable/LootItemMenu.java
@@ -1,0 +1,178 @@
+package de.c4t4lysm.catamines.utils.menusystem.menus.minemenus.compositionmenu.blockloottable;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.ItemStackBuilder;
+import de.c4t4lysm.catamines.utils.menusystem.Menu;
+import de.c4t4lysm.catamines.utils.menusystem.PlayerMenuUtility;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineLootItem;
+import de.c4t4lysm.catamines.utils.mine.mines.CuboidCataMine;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+public class LootItemMenu extends Menu {
+
+    private final CuboidCataMine mine;
+    private final CataMineLootItem item;
+
+    public LootItemMenu(PlayerMenuUtility playerMenuUtility) {
+        super(playerMenuUtility);
+        playerMenuUtility.setMenu(this);
+        this.mine = playerMenuUtility.getMine();
+        this.item = playerMenuUtility.getItem();
+    }
+
+    @Override
+    public String getMenuName() {
+        return CataMines.getInstance().getLangString("GUI.Configure-Item-Drop-Chances-Menu.Title").replaceAll("%itemChance%", String.valueOf(item.getChance()));
+    }
+
+    @Override
+    public int getSlots() {
+        return 54;
+    }
+
+    @Override
+    public void handleMenu(InventoryClickEvent event) {
+
+        Player player = (Player) event.getWhoClicked();
+
+        event.setCancelled(true);
+        double addPercentage = 0;
+        switch (event.getRawSlot()) {
+            case 45:
+                new LootItemListMenu(playerMenuUtility).open();
+                player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.3F, 1F);
+                return;
+            case 6:
+                item.setFortune(!item.isFortune());
+                mine.save();
+                updateMenus();
+                return;
+            case 3 * 9 - 9:
+                addPercentage = 0.001;
+                break;
+            case 3 * 9 - 8:
+            case 5 * 9 - 9:
+                addPercentage = 0.01;
+                break;
+            case 3 * 9 - 7:
+            case 5 * 9 - 8:
+                addPercentage = 0.1;
+                break;
+            case 3 * 9 - 6:
+            case 5 * 9 - 7:
+                addPercentage = 1;
+                break;
+            case 4 * 9 - 9:
+                addPercentage = 0.005;
+                break;
+            case 4 * 9 - 8:
+                addPercentage = 0.05;
+                break;
+            case 4 * 9 - 7:
+                addPercentage = 0.5;
+                break;
+            case 4 * 9 - 6:
+                addPercentage = 5;
+                break;
+            case 5 * 9 - 6:
+                addPercentage = 10;
+                break;
+            case 3 * 9 - 4:
+            case 42:
+                addPercentage = -1;
+                break;
+            case 3 * 9 - 3:
+            case 5 * 9 - 2:
+                addPercentage = -0.1;
+                break;
+            case 3 * 9 - 2:
+            case 5 * 9 - 1:
+                addPercentage = -0.01;
+                break;
+            case 3 * 9 - 1:
+                addPercentage = -0.001;
+                break;
+            case 4 * 9 - 4:
+                addPercentage = -5;
+                break;
+            case 4 * 9 - 3:
+                addPercentage = -0.5;
+                break;
+            case 4 * 9 - 2:
+                addPercentage = -0.05;
+                break;
+            case 4 * 9 - 1:
+                addPercentage = -0.005;
+                break;
+            case 5 * 9 - 4:
+                addPercentage = -10;
+                break;
+        }
+
+        if (addPercentage == 0) {
+            return;
+        }
+        try {
+            item.setChance(item.getChance() + addPercentage);
+        } catch (IllegalArgumentException exception) {
+            event.getWhoClicked().sendMessage(CataMines.PREFIX + exception.getMessage());
+        }
+        mine.save();
+        updateMenus();
+    }
+
+    @Override
+    public void setMenuItems() {
+        inventory.setItem(13, item.getItem());
+
+        if (item.isFortune()) {
+            inventory.setItem(6, ItemStackBuilder.buildItem(
+                    Material.LIME_DYE,
+                    CataMines.getInstance().getLangString("GUI.Configure-Item-Drop-Chances-Menu.Items.Fortune.Active.Name"),
+                    CataMines.getInstance().getLangStringList("GUI.Configure-Item-Drop-Chances-Menu.Items.Fortune.Active.Lore")));
+        } else {
+            inventory.setItem(6, ItemStackBuilder.buildItem(
+                    Material.GRAY_DYE,
+                    CataMines.getInstance().getLangString("GUI.Configure-Item-Drop-Chances-Menu.Items.Fortune.Inactive.Name"),
+                    CataMines.getInstance().getLangStringList("GUI.Configure-Item-Drop-Chances-Menu.Items.Fortune.Inactive.Lore")));
+        }
+
+        String increaseBy = CataMines.getInstance().getLangString("GUI.Universal.Increase-By");
+        String decreaseBy = CataMines.getInstance().getLangString("GUI.Universal.Decrease-By");
+
+        inventory.setItem(3 * 9 - 9, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.001")));
+        inventory.setItem(3 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.01")));
+        inventory.setItem(3 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+
+        inventory.setItem(4 * 9 - 9, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.005")));
+        inventory.setItem(4 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.05")));
+        inventory.setItem(4 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "5")));
+
+        inventory.setItem(5 * 9 - 9, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.01")));
+        inventory.setItem(5 * 9 - 8, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(5 * 9 - 7, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 6, ItemStackBuilder.buildItem(Material.LIME_WOOL, increaseBy.replaceAll("%number%", "10")));
+
+        inventory.setItem(3 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(3 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(3 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.01")));
+        inventory.setItem(3 * 9 - 1, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.001")));
+
+        inventory.setItem(4 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "5")));
+        inventory.setItem(4 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.5")));
+        inventory.setItem(4 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.05")));
+        inventory.setItem(4 * 9 - 1, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.005")));
+
+        inventory.setItem(5 * 9 - 4, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "10")));
+        inventory.setItem(5 * 9 - 3, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "1")));
+        inventory.setItem(5 * 9 - 2, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.1")));
+        inventory.setItem(5 * 9 - 1, ItemStackBuilder.buildItem(Material.RED_WOOL, decreaseBy.replaceAll("%number%", "0.01")));
+
+        inventory.setItem(45, ItemStackBuilder.buildItem(Material.ARROW, CataMines.getInstance().getLangString("GUI.Universal.Back-To-Block-Menu.Name"), CataMines.getInstance().getLangStringList("GUI.Universal.Back-To-Block-Menu.Lore")));
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/AbstractCataMine.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/AbstractCataMine.java
@@ -1,0 +1,664 @@
+package de.c4t4lysm.catamines.utils.mine;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.function.pattern.RandomPattern;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.configuration.FileConfig;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.util.BoundingBox;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public abstract class AbstractCataMine implements Cloneable {
+
+    protected String name;
+    protected String world;
+    protected Region region;
+    protected List<CataMineBlock> blocks = new ArrayList<>();
+    protected RandomPattern randomPattern;
+    protected int resetDelay;
+    protected double resetPercentage;
+    protected CataMineResetMode resetMode = CataMineResetMode.TIME_PERCENTAGE;
+    protected boolean replaceMode;
+    protected boolean warnHotbar;
+    protected String warnHotbarMessage = "default";
+    protected boolean warn;
+    protected boolean warnGlobal;
+    protected String warnMessage = "default";
+    protected String resetMessage = "default";
+    protected List<Integer> warnSeconds = CataMines.getInstance().getFileManager().getDefaultIntegers("Default-Warn-Seconds");
+    protected int warnDistance = 5;
+    protected boolean teleportPlayers;
+    protected boolean isStopped;
+    protected Location teleportLocation;
+    protected int minEfficiencyLvl;
+    protected boolean teleportPlayersToResetLocation;
+    protected Location teleportResetLocation;
+    protected long blockCount;
+    protected boolean runnable;
+    protected boolean firstCycle;
+    protected int countdown;
+    // Block count
+    Random random = new Random();
+    protected int countdownForAutoReset = random.nextInt(200) + 500;
+
+    public AbstractCataMine(String name, Region region) {
+        this.name = name;
+        if (region != null) {
+            this.region = region.clone();
+            this.world = region.getWorld() != null ? region.getWorld().getName() : null;
+        }
+    }
+
+    public void run() {
+
+        if (isStopped || !checkRunnable()) {
+            return;
+        }
+
+        switch (resetMode) {
+            case TIME:
+                if (resetDelay <= 0) return;
+                if (!firstCycle) {
+                    --countdown;
+                } else {
+                    firstCycle = false;
+                    countdown = resetDelay;
+                }
+
+                if (warn) {
+                    if (warnSeconds.contains(countdown)) {
+                        broadcastWarnMessage();
+                    }
+                }
+
+                if (countdown <= 0) {
+                    reset();
+                    firstCycle = true;
+                }
+                break;
+            case PERCENTAGE:
+                --countdownForAutoReset;
+                if (countdownForAutoReset <= 0) {
+                    forceReset();
+                    countdownForAutoReset = random.nextInt(200) + 500;
+                }
+                if (getRemainingBlocksPer() <= resetPercentage) {
+                    reset();
+                }
+                break;
+            case TIME_PERCENTAGE:
+                if (resetDelay <= 0) return;
+                if (!firstCycle) {
+                    --countdown;
+                } else {
+                    firstCycle = false;
+                    countdown = resetDelay;
+                }
+
+                if (warn) {
+                    if (warnSeconds.contains(countdown)) {
+                        broadcastWarnMessage();
+                    }
+                }
+
+                if (countdown <= 0) {
+                    reset();
+                    firstCycle = true;
+                    break;
+                }
+
+                if (getRemainingBlocksPer() <= resetPercentage) {
+                    reset();
+                    firstCycle = true;
+                    break;
+                }
+                break;
+        }
+
+        if (warnHotbar) {
+            broadcastHotbar();
+        }
+    }
+
+    public void reset() {
+        try (EditSession editSession = WorldEdit.getInstance().newEditSession(region.getWorld())) {
+
+            if (blockCount != getTotalBlocks()) {
+                blockCount = getTotalBlocks();
+                if (!replaceMode) {
+                    editSession.setBlocks(region, randomPattern);
+                } else {
+                    editSession.replaceBlocks(region, Collections.singleton(BlockTypes.AIR.getDefaultState().toBaseBlock()), randomPattern);
+                }
+            }
+
+            if (warn) {
+                broadcastResetMessage();
+            }
+            if (teleportPlayers) {
+                teleportPlayers();
+            }
+
+        } catch (MaxChangedBlocksException exception) {
+            throw new IllegalArgumentException(name + " tried to set too many blocks!");
+        } catch (NoSuchMethodError exception) {
+            throw new NoSuchMethodError("Could not reset " + name + " because your version of WorldEdit is too old!");
+        }
+    }
+
+    public void forceReset() {
+        blockCount = 0;
+        reset();
+    }
+
+    public boolean checkRunnable() {
+        if (region == null) {
+            FileConfig fileConfig = new FileConfig(CataMines.getInstance().getDataFolder() + "/mines", name + ".yml");
+            if (Bukkit.getWorld(world) != null) {
+                loadRegion(fileConfig);
+            } else {
+                setStopped(true);
+                CataMines.getInstance().getLogger().warning("World " + world + " not found. Stopped " + name);
+                return false;
+            }
+        }
+        setRunnable(region != null && randomPattern != null);
+        return runnable;
+    }
+
+    public boolean isRunnable() {
+        return runnable;
+    }
+
+    public void setRunnable(boolean runnable) {
+        this.runnable = runnable;
+    }
+
+    public void loadRegion(FileConfig fileConfig) {
+        Location minimumPoint = (Location) fileConfig.get("Mine.region.p1");
+        Location maximumPoint = (Location) fileConfig.get("Mine.region.p2");
+
+        if (minimumPoint == null || maximumPoint == null || minimumPoint.getWorld() == null || maximumPoint.getWorld() == null || !(Objects.equals(minimumPoint.getWorld(), maximumPoint.getWorld()))) {
+            CataMines.getInstance().getLogger().severe("Could not load region of " + name);
+            setStopped(true);
+            return;
+        }
+
+        region = new CuboidRegion(BukkitAdapter.adapt(minimumPoint.getWorld()),
+                BlockVector3.at(minimumPoint.getX(), minimumPoint.getY(), minimumPoint.getZ()),
+                BlockVector3.at(maximumPoint.getX(), maximumPoint.getY(), maximumPoint.getZ()));
+
+    }
+
+    public void addBlock(CataMineBlock cataMineBlock) {
+        double chanceSum = 0;
+        for (CataMineBlock block : blocks) {
+            if (block.getBlockData().equals(cataMineBlock.getBlockData())) {
+                continue;
+            }
+
+            chanceSum += block.getChance();
+        }
+
+        chanceSum += cataMineBlock.getChance();
+        if (chanceSum > 100)
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Chance-Over-100"));
+
+        for (int i = 0; i < blocks.size(); i++) {
+            if (blocks.get(i).getBlockData().equals(cataMineBlock.getBlockData())) {
+                blocks.set(i, cataMineBlock);
+                blocksToRandomPattern();
+                return;
+            }
+        }
+
+        blocks.add(cataMineBlock);
+        blocksToRandomPattern();
+    }
+
+    public void clearComposition() {
+        blocks.clear();
+        blocksToRandomPattern();
+    }
+
+    public void removeBlock(BlockData blockData) {
+        if (!containsBlockData(blockData)) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Block-Not-In-Composition"));
+        }
+        blocks.remove(getBlock(blockData));
+        blocksToRandomPattern();
+    }
+
+    public void removeBlock(int index) {
+        blocks.remove(index);
+        blocksToRandomPattern();
+    }
+
+    public double getCompositionChance() {
+
+        double compositionChance = 0;
+
+        for (CataMineBlock block : blocks) {
+            compositionChance += block.getChance();
+        }
+
+        return Math.round(compositionChance * 100) / 100d;
+    }
+
+    public double getBlockChance(Material material) {
+        double chance = 0;
+
+        for (CataMineBlock block : blocks) {
+            if (block.getBlockData().getMaterial().equals(material)) {
+                chance = block.getChance();
+            }
+        }
+
+        return chance;
+    }
+
+    public void setBlockChance(CataMineBlock block, double chance) {
+        double chanceSum = 0;
+        for (CataMineBlock cataMineBlock : blocks) {
+            if (cataMineBlock.equals(block)) {
+                chanceSum += chance;
+                continue;
+            }
+
+            chanceSum += cataMineBlock.getChance();
+        }
+
+        if (chanceSum > 100) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Chance"));
+        }
+
+        block.setChance(chance);
+        blocksToRandomPattern();
+    }
+
+    public void setBlockChance(BlockData blockData, double chance) {
+        setBlockChance(getBlock(blockData), chance);
+    }
+
+    public CataMineBlock getBlock(BlockData blockData) {
+        for (CataMineBlock block : blocks) {
+            if (block.getBlockData().equals(blockData)) {
+                return block;
+            }
+        }
+
+        return null;
+    }
+
+    public boolean containsBlock(CataMineBlock block) {
+        return blocks.contains(block);
+    }
+
+    public boolean containsBlockData(BlockData blockData) {
+        for (CataMineBlock block : blocks) {
+            if (block.getBlockData().equals(blockData)) return true;
+        }
+
+        return false;
+    }
+
+    public boolean containsBlockMaterial(Material material) {
+        for (CataMineBlock block : blocks) {
+            if (block.getBlockData().getMaterial().equals(material)) return true;
+        }
+
+        return false;
+    }
+
+    public void blocksToRandomPattern() {
+
+        if (blocks.isEmpty() || blocks.stream().allMatch(cataMineBlock -> cataMineBlock.getChance() == 0)) {
+            randomPattern = null;
+            return;
+        }
+
+        randomPattern = new RandomPattern();
+
+        blocks.stream().filter(cataMineBlock -> cataMineBlock.getChance() > 0)
+                .forEach(cataMineBlock -> randomPattern.add(BukkitAdapter.adapt(cataMineBlock.getBlockData()).toBaseBlock(), cataMineBlock.getChance()));
+    }
+
+    public String getTranslatedTimeMessage() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("");
+        String.format("%");
+        return null;
+    }
+
+    public void broadcastHotbar() {
+        String finalMessage = Utils.setPlaceholders(getWarnHotbarMessage(resetMode), this);
+        getPlayersInDistance().forEach(player -> {
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(finalMessage));
+        });
+    }
+
+    public void broadcastWarnMessage() {
+        String finalWarnMessage = Utils.setPlaceholders(getWarnMessage(), this);
+        getPlayersToWarn().forEach(player -> {
+            Arrays.stream(finalWarnMessage.split("/n")).forEach(player::sendMessage);
+        });
+    }
+
+    public void broadcastResetMessage() {
+        String finalResetMessage = Utils.setPlaceholders(getResetMessage(), this);
+        getPlayersToWarn().forEach(player -> {
+            Arrays.stream(finalResetMessage.split("/n")).forEach(player::sendMessage);
+        });
+    }
+
+
+    public void teleportPlayers() {
+        if (!teleportPlayersToResetLocation) {
+            getPlayersInRegion().forEach(player -> player.teleport(new Location(player.getWorld(), player.getLocation().getX(), region.getMaximumPoint().getY() + 1,
+                    player.getLocation().getZ(), player.getLocation().getYaw(), player.getLocation().getPitch())));
+        } else {
+            if (teleportResetLocation == null) {
+                return;
+            }
+            getPlayersInRegion().forEach(player -> player.teleport(teleportResetLocation));
+        }
+    }
+
+    public Collection<? extends Player> getPlayersInRegion() {
+        return Bukkit.getOnlinePlayers().stream().filter(player -> Objects.equals(region.getWorld().getName(), player.getWorld().getName()) &&
+                region.contains(BlockVector3.at(player.getLocation().getX(), player.getLocation().getY(), player.getLocation().getZ()))).collect(Collectors.toList());
+    }
+
+    public Collection<? extends Player> getPlayersInDistance() {
+        return Bukkit.getOnlinePlayers().stream().filter(player -> Objects.equals(region.getWorld().getName(), player.getWorld().getName()) &&
+                player.getBoundingBox().overlaps(
+                        new BoundingBox(
+                                region.getMinimumPoint().getX(),
+                                region.getMinimumPoint().getY(),
+                                region.getMinimumPoint().getZ(),
+                                region.getMaximumPoint().getX() + 1,
+                                region.getMaximumPoint().getY() + 1,
+                                region.getMaximumPoint().getZ() + 1)
+                                .expand(warnDistance))).collect(Collectors.toList());
+    }
+
+    public Collection<? extends Player> getPlayersToWarn() {
+        return !warnGlobal ? getPlayersInDistance() : Bukkit.getOnlinePlayers();
+    }
+
+    public String getFormattedTimeString() {
+        CataMines plugin = CataMines.getInstance();
+        String output;
+
+        switch (countdown) {
+            case 3600:
+                output = plugin.getLangString("Time.Hour");
+                break;
+            case 60:
+                output = plugin.getLangString("Time.Minute");
+                break;
+            case 1:
+                output = plugin.getLangString("Time.Second");
+                break;
+            default:
+                if (countdown >= 3600) {
+                    output = plugin.getLangString("Time.Hours");
+                } else if (countdown >= 60) {
+                    output = plugin.getLangString("Time.Minutes");
+                } else {
+                    output = plugin.getLangString("Time.Seconds");
+                }
+        }
+
+        return output;
+    }
+
+    public abstract void handleBlockBreak(BlockBreakEvent event);
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getWorld() {
+        return world;
+    }
+
+    public void setWorld(String world) {
+        this.world = world;
+    }
+
+    public Region getRegion() {
+        return region;
+    }
+
+    public void setRegion(Region region) {
+        this.region = region;
+        this.world = region.getWorld().getName();
+    }
+
+    public List<CataMineBlock> getBlocks() {
+        return blocks;
+    }
+
+    public void setBlocks(List<CataMineBlock> blocks) {
+        this.blocks = blocks;
+    }
+
+    public RandomPattern getRandomPattern() {
+        return randomPattern;
+    }
+
+    public void setRandomPattern(RandomPattern randomPattern) {
+        this.randomPattern = randomPattern;
+    }
+
+    public CataMineResetMode getResetMode() {
+        return resetMode;
+    }
+
+    public void setResetMode(CataMineResetMode resetMode) {
+        this.resetMode = resetMode;
+    }
+
+    public int getResetDelay() {
+        return resetDelay;
+    }
+
+    public void setResetDelay(int resetDelay) {
+        this.resetDelay = resetDelay;
+    }
+
+    public double getResetPercentage() {
+        return resetPercentage;
+    }
+
+    public void setResetPercentage(double resetPercentage) {
+        if (resetPercentage < 0) resetPercentage = 0;
+        if (resetPercentage > 100) resetPercentage = 100;
+        this.resetPercentage = Math.round(resetPercentage * 100) / 100d;
+    }
+
+    public boolean isReplaceMode() {
+        return replaceMode;
+    }
+
+    public void setReplaceMode(boolean replaceMode) {
+        this.replaceMode = replaceMode;
+    }
+
+    public boolean isWarn() {
+        return warn;
+    }
+
+    public void setWarn(boolean warn) {
+        this.warn = warn;
+    }
+
+    public boolean isWarnHotbar() {
+        return warnHotbar;
+    }
+
+    public void setWarnHotbar(boolean warnHotbar) {
+        this.warnHotbar = warnHotbar;
+    }
+
+    public String getWarnHotbarMessage(CataMineResetMode resetMode) {
+        return warnHotbarMessage.equalsIgnoreCase("default") ? CataMines.getInstance().getDefaultString("Default-Hotbar-Message-" + StringUtils.capitalize(resetMode.name())) : warnHotbarMessage;
+    }
+
+    public void setWarnHotbarMessage(String warnHotbarMessage) {
+        this.warnHotbarMessage = warnHotbarMessage;
+    }
+
+    public boolean isWarnGlobal() {
+        return warnGlobal;
+    }
+
+    public void setWarnGlobal(boolean warnGlobal) {
+        this.warnGlobal = warnGlobal;
+    }
+
+    public String getWarnMessage() {
+        return warnMessage.equalsIgnoreCase("default") ? CataMines.getInstance().getDefaultString("Default-Warn-Message") : warnMessage;
+    }
+
+    public void setWarnMessage(String warnMessage) {
+        this.warnMessage = warnMessage;
+    }
+
+    public String getResetMessage() {
+        return resetMessage.equalsIgnoreCase("default") ? CataMines.getInstance().getDefaultString("Default-Reset-Message") : resetMessage;
+    }
+
+    public void setResetMessage(String resetMessage) {
+        this.resetMessage = resetMessage;
+    }
+
+    public List<Integer> getWarnSeconds() {
+        return warnSeconds;
+    }
+
+    public void setWarnSeconds(List<Integer> warnSeconds) {
+        this.warnSeconds = warnSeconds;
+    }
+
+    public int getWarnDistance() {
+        return warnDistance;
+    }
+
+    public void setWarnDistance(int warnDistance) {
+        this.warnDistance = warnDistance;
+    }
+
+    public boolean isTeleportPlayers() {
+        return teleportPlayers;
+    }
+
+    public void setTeleportPlayers(boolean teleportPlayers) {
+        this.teleportPlayers = teleportPlayers;
+    }
+
+    public boolean isTeleportPlayersToResetLocation() {
+        return teleportPlayersToResetLocation;
+    }
+
+    public void setTeleportPlayersToResetLocation(boolean teleportPlayersToResetLocation) {
+        this.teleportPlayersToResetLocation = teleportPlayersToResetLocation;
+    }
+
+    public boolean isStopped() {
+        return isStopped;
+    }
+
+    public void setStopped(boolean stopped) {
+        isStopped = stopped;
+    }
+
+    protected abstract Location getTeleportLocation();
+
+    public void setTeleportLocation(Location teleportLocation) {
+        this.teleportLocation = teleportLocation;
+    }
+
+    public Location getTeleportResetLocation() {
+        return teleportResetLocation;
+    }
+
+    public void setTeleportResetLocation(Location teleportResetLocation) {
+        this.teleportResetLocation = teleportResetLocation;
+    }
+
+    public int getMinEfficiencyLvl() {
+        return minEfficiencyLvl;
+    }
+
+    public void setMinEfficiencyLvl(int minEfficiencyLvl) {
+        this.minEfficiencyLvl = minEfficiencyLvl;
+    }
+
+    public boolean isFirstCycle() {
+        return firstCycle;
+    }
+
+    public void setFirstCycle(boolean firstCycle) {
+        this.firstCycle = firstCycle;
+    }
+
+    public int getCountdown() {
+        return countdown;
+    }
+
+    public void setCountdown(int countdown) {
+        this.countdown = countdown;
+    }
+
+    @Override
+    public AbstractCataMine clone() {
+        try {
+            return (AbstractCataMine) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+
+    public abstract long getTotalBlocks();
+
+    public long getBlockCount() {
+        return blockCount;
+    }
+
+    public void setBlockCount(long blockCount) {
+        this.blockCount = blockCount;
+    }
+
+    public long getMinedBlocks() {
+        return getTotalBlocks() - getBlockCount();
+    }
+
+    public abstract double getRemainingBlocksPer();
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineBlock.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineBlock.java
@@ -1,0 +1,137 @@
+package de.c4t4lysm.catamines.utils.mine.components;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.Bukkit;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CataMineBlock implements Cloneable, ConfigurationSerializable {
+
+    private BlockData blockData;
+    private double chance;
+    private boolean addLootTable;
+
+    private List<CataMineLootItem> lootTable;
+
+    public CataMineBlock(BlockData blockData, double chance) {
+        this(blockData, chance, false, new ArrayList<>());
+    }
+
+    public CataMineBlock(BlockData blockData, double chance, boolean addLootTable) {
+        this(blockData, chance, addLootTable, new ArrayList<>());
+    }
+
+    public CataMineBlock(BlockData blockData, double chance, List<CataMineLootItem> lootTable) {
+        this(blockData, chance, false, lootTable);
+    }
+
+    public CataMineBlock(BlockData blockData, double chance, boolean addLootTable, List<CataMineLootItem> lootTable) {
+        if (!blockData.getMaterial().isBlock() || chance < 0 || chance > 100) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Block-Configuration"));
+        }
+
+        this.blockData = blockData;
+        this.chance = Math.round(chance * 100) / 100d;
+        this.addLootTable = addLootTable;
+        this.lootTable = lootTable;
+    }
+
+    public static CataMineBlock deserialize(Map<String, Object> map) {
+        BlockData blockData = Bukkit.createBlockData(((String) map.get("block")).toLowerCase());
+        double chance = 0d;
+        if (map.containsKey("chance")) {
+            chance = (double) map.get("chance");
+        }
+        boolean addLootTable = false;
+        if (map.containsKey("addLootTable")) {
+            addLootTable = (boolean) map.get("addLootTable");
+        }
+
+        ArrayList<Map<String, Object>> serializedLootTable = new ArrayList<>();
+        if (map.containsKey("lootTable")) {
+            serializedLootTable = (ArrayList<Map<String, Object>>) map.get("lootTable");
+        }
+        if (serializedLootTable.isEmpty()) {
+            return new CataMineBlock(blockData, chance, addLootTable);
+        }
+
+        List<CataMineLootItem> lootTable = new ArrayList<>();
+        for (Map<String, Object> loot : serializedLootTable) {
+            lootTable.add(CataMineLootItem.deserialize(loot));
+        }
+
+        return new CataMineBlock(blockData, chance, addLootTable, lootTable);
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("block", blockData.getAsString(true));
+        result.put("chance", chance);
+        result.put("addLootTable", addLootTable);
+
+        ArrayList<Map<String, Object>> mappedLootTable = new ArrayList<>();
+
+        for (CataMineLootItem lootItem : lootTable) {
+            mappedLootTable.add(lootItem.serialize());
+        }
+
+        result.put("lootTable", mappedLootTable);
+
+        return result;
+    }
+
+    public BlockData getBlockData() {
+        return blockData;
+    }
+
+    public void setBlockData(BlockData blockData) {
+        if (!blockData.getMaterial().isBlock()) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Material-Not-Solid"));
+        }
+        this.blockData = blockData;
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public void setChance(double chance) {
+        if (chance < 0 || chance > 100) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Chance"));
+        }
+        this.chance = Math.round(chance * 100) / 100d;
+    }
+
+    public boolean isAddLootTable() {
+        return addLootTable;
+    }
+
+    public void setAddLootTable(boolean addLootTable) {
+        this.addLootTable = addLootTable;
+    }
+
+    public List<CataMineLootItem> getLootTable() {
+        return lootTable;
+    }
+
+    public void setLootTable(List<CataMineLootItem> lootTable) {
+        this.lootTable = lootTable;
+    }
+
+    @Override
+    public CataMineBlock clone() {
+        try {
+            return (CataMineBlock) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineLootItem.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineLootItem.java
@@ -1,0 +1,105 @@
+package de.c4t4lysm.catamines.utils.mine.components;
+
+import de.c4t4lysm.catamines.CataMines;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class CataMineLootItem implements ConfigurationSerializable {
+
+    Random random = new Random();
+    private ItemStack item;
+    private double chance;
+    private boolean fortune;
+
+    public CataMineLootItem(ItemStack item) {
+        this.item = item;
+        this.chance = 100d;
+        this.fortune = false;
+    }
+
+    public CataMineLootItem(ItemStack item, double chance) {
+        this(item, chance, false);
+    }
+
+    public CataMineLootItem(ItemStack item, double chance, boolean fortune) {
+        this.item = item;
+        if (chance < 0 || chance > 100) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Chance"));
+        }
+        this.chance = Math.round(chance * 1000) / 1000d;
+        this.fortune = fortune;
+    }
+
+    public static CataMineLootItem deserialize(Map<String, Object> serializedLootItem) {
+
+        ItemStack item = null;
+        if (serializedLootItem.containsKey("item")) {
+            item = ItemStack.deserialize((Map<String, Object>) serializedLootItem.get("item"));
+        }
+
+        double chance = 100d;
+        if (serializedLootItem.containsKey("chance")) {
+            chance = (double) serializedLootItem.get("chance");
+        }
+
+        boolean fortune = false;
+        if (serializedLootItem.containsKey("fortune")) {
+            fortune = (boolean) serializedLootItem.get("fortune");
+        }
+
+        return new CataMineLootItem(item, chance, fortune);
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> serializedLootItem = new LinkedHashMap<>();
+
+        serializedLootItem.put("item", item.serialize());
+        serializedLootItem.put("chance", chance);
+        serializedLootItem.put("fortune", fortune);
+
+        return serializedLootItem;
+    }
+
+    public ItemStack getItem() {
+        return item;
+    }
+
+    public void setItem(ItemStack item) {
+        this.item = item;
+    }
+
+    public int getDropCount(int fortune) {
+        ItemStack fortuneItem = item.clone();
+        if (fortune > 0) {
+            int multiplier = random.nextInt(fortune + 2) - 1;
+            if (multiplier < 0) multiplier = 0;
+
+            return fortuneItem.getAmount() * (multiplier + 1);
+        }
+        return fortuneItem.getAmount();
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public void setChance(double chance) {
+        if (chance < 0 || chance > 100) {
+            throw new IllegalArgumentException(CataMines.getInstance().getLangString("Error-Messages.Mine.Invalid-Chance"));
+        }
+        this.chance = Math.round(chance * 1000) / 1000d;
+    }
+
+    public boolean isFortune() {
+        return fortune;
+    }
+
+    public void setFortune(boolean fortune) {
+        this.fortune = fortune;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineResetMode.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/components/CataMineResetMode.java
@@ -1,0 +1,13 @@
+package de.c4t4lysm.catamines.utils.mine.components;
+
+public enum CataMineResetMode {
+    TIME,
+    PERCENTAGE,
+    TIME_PERCENTAGE;
+
+    private final static CataMineResetMode[] resetModes = values();
+
+    public CataMineResetMode next() {
+        return resetModes[(this.ordinal() + 1) % resetModes.length];
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/mines/CuboidCataMine.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/mines/CuboidCataMine.java
@@ -1,0 +1,416 @@
+package de.c4t4lysm.catamines.utils.mine.mines;
+
+import com.google.common.base.Enums;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.utils.configuration.FileConfig;
+import de.c4t4lysm.catamines.utils.mine.AbstractCataMine;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineBlock;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineLootItem;
+import de.c4t4lysm.catamines.utils.mine.components.CataMineResetMode;
+import org.bukkit.*;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class CuboidCataMine extends AbstractCataMine implements Cloneable, ConfigurationSerializable {
+
+    private final Random random = new Random();
+
+    private File file;
+    private YamlConfiguration fileConfig;
+
+    public CuboidCataMine(String name, Region region) {
+        super(name, region);
+    }
+
+    public static CuboidCataMine deserialize(Map<String, Object> serializedCataMine) {
+        Logger logger = CataMines.getInstance().getLogger();
+
+        String name = (String) serializedCataMine.get("name");
+
+        Location minimumPoint = null;
+        Location maximumPoint = null;
+        String world = "";
+        Region region = null;
+
+        if (serializedCataMine.containsKey("region")) {
+            Map<String, Object> regionLocations = (Map<String, Object>) serializedCataMine.get("region");
+            world = (String) regionLocations.get("world");
+            World bukkitWorld = null;
+            boolean loadable = true;
+            try {
+                bukkitWorld = Bukkit.getWorld(world);
+            } catch (Throwable throwable) {
+                logger.severe("World " + regionLocations.get("world") + " not found");
+            }
+            if (bukkitWorld == null) {
+                logger.severe("Could not find world " + world + ".");
+                loadable = false;
+            }
+            try {
+                minimumPoint = (Location) regionLocations.get("p1");
+                maximumPoint = (Location) regionLocations.get("p2");
+            } catch (Throwable throwable) {
+                logger.severe("Could not load locations");
+                loadable = false;
+            }
+
+            if (minimumPoint == null || maximumPoint == null || !Objects.equals(minimumPoint.getWorld(), maximumPoint.getWorld())) {
+                logger.severe("Could not load locations, does the world exist?");
+                loadable = false;
+            }
+
+            if (loadable)
+                region = new CuboidRegion(BukkitAdapter.adapt(minimumPoint.getWorld()), BlockVector3.at(minimumPoint.getX(), minimumPoint.getY(),
+                        minimumPoint.getZ()), BlockVector3.at(maximumPoint.getX(), maximumPoint.getY(), maximumPoint.getZ()));
+        }
+
+        ArrayList<CataMineBlock> blocks = new ArrayList<>();
+
+        if (serializedCataMine.containsKey("composition")) {
+            ArrayList<Map<String, Object>> serializedBlocks = (ArrayList<Map<String, Object>>) serializedCataMine.get("composition");
+
+            for (Map<String, Object> serializedBlock : serializedBlocks) {
+                blocks.add(CataMineBlock.deserialize(serializedBlock));
+            }
+        }
+
+        CataMineResetMode resetMode = CataMineResetMode.TIME;
+        if (serializedCataMine.containsKey("resetMode")) {
+            resetMode = Enums.getIfPresent(CataMineResetMode.class, (String) serializedCataMine.get("resetMode")).or(CataMineResetMode.TIME);
+        }
+
+        int resetDelay = 0;
+        if (serializedCataMine.containsKey("resetDelay")) {
+            resetDelay = (int) serializedCataMine.get("resetDelay");
+        }
+
+        int countdown = resetDelay;
+        if (serializedCataMine.containsKey("countdown")) {
+            countdown = (int) serializedCataMine.get("countdown");
+        }
+
+        double resetPercentage = 0;
+        if (serializedCataMine.containsKey("resetPercentage")) {
+            resetPercentage = (double) serializedCataMine.get("resetPercentage");
+        }
+
+        boolean replaceMode = false;
+        if (serializedCataMine.containsKey("replaceMode")) {
+            replaceMode = (boolean) serializedCataMine.get("replaceMode");
+        }
+
+        boolean teleportPlayers = false;
+        if (serializedCataMine.containsKey("teleportPlayers")) {
+            teleportPlayers = (boolean) serializedCataMine.get("teleportPlayers");
+        }
+
+        boolean teleportPlayersToResetLocation = false;
+        if (serializedCataMine.containsKey("teleportPlayersToResetLocation")) {
+            teleportPlayersToResetLocation = (boolean) serializedCataMine.get("teleportPlayersToResetLocation");
+        }
+
+        boolean warnHotbar = false;
+        String warnHotbarMessage = "&a%seconds%";
+        boolean warn = false;
+        boolean warnGlobal = false;
+        String warnMessage = "default";
+        String resetMessage = "default";
+        List<Integer> warnSeconds = Arrays.asList(1, 2, 3, 5, 20, 60);
+        int warnDistance = 5;
+        if (serializedCataMine.containsKey("warn")) {
+            Map<String, Object> serializedWarn = (Map<String, Object>) serializedCataMine.get("warn");
+            if (serializedWarn.containsKey("warnHotbar")) {
+                warnHotbar = (boolean) serializedWarn.get("warnHotbar");
+            }
+            if (serializedWarn.containsKey("warnHotbarMessage")) {
+                warnHotbarMessage = (String) serializedWarn.get("warnHotbarMessage");
+            }
+            if (serializedWarn.containsKey("enableWarn")) {
+                warn = (boolean) serializedWarn.get("enableWarn");
+            }
+            if (serializedWarn.containsKey("warnGlobal")) {
+                warnGlobal = (boolean) serializedWarn.get("warnGlobal");
+            }
+            if (serializedWarn.containsKey("warnMessage")) {
+                warnMessage = (String) serializedWarn.get("warnMessage");
+            }
+            if (serializedWarn.containsKey("resetMessage")) {
+                resetMessage = (String) serializedWarn.get("resetMessage");
+            }
+            if (serializedWarn.containsKey("warnSeconds")) {
+                warnSeconds = (List<Integer>) serializedWarn.get("warnSeconds");
+            }
+            if (serializedWarn.containsKey("warnDistance")) {
+                warnDistance = (int) serializedWarn.get("warnDistance");
+            }
+        }
+        int minEfficiencyLvl = 0;
+        if (serializedCataMine.containsKey("minEfficiencyLvl")) {
+            minEfficiencyLvl = (int) serializedCataMine.get("minEfficiencyLvl");
+        }
+
+        Location teleportLocation = null;
+        if (serializedCataMine.containsKey("teleportLocation")) {
+            teleportLocation = (Location) serializedCataMine.get("teleportLocation");
+        }
+
+        Location teleportResetLocation = null;
+        if (serializedCataMine.containsKey("teleportResetLocation")) {
+            teleportResetLocation = (Location) serializedCataMine.get("teleportResetLocation");
+        }
+
+        boolean isStopped = false;
+        if (serializedCataMine.containsKey("isStopped")) {
+            isStopped = (boolean) serializedCataMine.get("isStopped");
+        }
+
+        CuboidCataMine mine = new CuboidCataMine(name, region);
+        mine.setWorld(world);
+        mine.setBlocks(blocks);
+        mine.setResetMode(resetMode);
+        mine.setResetDelay(resetDelay);
+        mine.setResetPercentage(resetPercentage);
+        mine.setReplaceMode(replaceMode);
+        mine.setWarnHotbar(warnHotbar);
+        mine.setWarnHotbarMessage(warnHotbarMessage);
+        mine.setWarn(warn);
+        mine.setWarnGlobal(warnGlobal);
+        mine.setWarnMessage(warnMessage);
+        mine.setResetMessage(resetMessage);
+        mine.setWarnSeconds(warnSeconds);
+        mine.setWarnDistance(warnDistance);
+        mine.setTeleportPlayers(teleportPlayers);
+        mine.setStopped(isStopped);
+        mine.setTeleportLocation(teleportLocation);
+        mine.setMinEfficiencyLvl(minEfficiencyLvl);
+        mine.setTeleportPlayersToResetLocation(teleportPlayersToResetLocation);
+        mine.setTeleportResetLocation(teleportResetLocation);
+
+        mine.setCountdown(countdown);
+        mine.blocksToRandomPattern();
+
+        if (region != null && mine.getRandomPattern() != null && resetMode != CataMineResetMode.TIME) mine.forceReset();
+        return mine;
+    }
+
+    @Override
+    @Nonnull
+    public Map<String, Object> serialize() {
+        Map<String, Object> mapSerializer = new LinkedHashMap<>();
+        mapSerializer.put("name", name);
+
+        if (region != null) {
+            Map<String, Object> mappedRegion = new LinkedHashMap<>();
+            mappedRegion.put("type", "CUBOID");
+            mappedRegion.put("world", region.getWorld().getName());
+
+            mappedRegion.put("p1", BukkitAdapter.adapt(BukkitAdapter.adapt(region.getWorld()), region.getMinimumPoint()));
+            mappedRegion.put("p2", BukkitAdapter.adapt(BukkitAdapter.adapt(region.getWorld()), region.getMaximumPoint()));
+
+            mapSerializer.put("region", mappedRegion);
+        }
+
+
+        ArrayList<Map<String, Object>> tempSerializeBlocks = new ArrayList<>();
+        for (CataMineBlock block : blocks) {
+            tempSerializeBlocks.add(block.serialize());
+        }
+
+        mapSerializer.put("composition", tempSerializeBlocks);
+
+        mapSerializer.put("resetMode", resetMode.name());
+        mapSerializer.put("resetDelay", resetDelay);
+        mapSerializer.put("countdown", countdown);
+        mapSerializer.put("resetPercentage", resetPercentage);
+        mapSerializer.put("replaceMode", replaceMode);
+        mapSerializer.put("teleportPlayers", teleportPlayers);
+        mapSerializer.put("teleportPlayersToResetLocation", teleportPlayersToResetLocation);
+        mapSerializer.put("isStopped", isStopped);
+        mapSerializer.put("warn", warn);
+
+        Map<String, Object> mappedWarn = new LinkedHashMap<>();
+        mappedWarn.put("warnHotbar", warnHotbar);
+        mappedWarn.put("warnHotbarMessage", warnHotbarMessage);
+        mappedWarn.put("enableWarn", warn);
+        mappedWarn.put("warnGlobal", warnGlobal);
+        mappedWarn.put("warnMessage", warnMessage);
+        mappedWarn.put("resetMessage", resetMessage);
+        mappedWarn.put("warnSeconds", warnSeconds);
+        mappedWarn.put("warnDistance", warnDistance);
+        mapSerializer.put("warn", mappedWarn);
+
+        mapSerializer.put("minEfficiencyLvl", minEfficiencyLvl);
+        mapSerializer.put("teleportLocation", teleportLocation);
+        mapSerializer.put("teleportResetLocation", teleportResetLocation);
+
+        return mapSerializer;
+    }
+
+    public void handleBlockBreak(BlockBreakEvent event) {
+
+        if (getMinEfficiencyLvl() > 0 && !event.getPlayer().hasPermission("catamines.break")) {
+            Player player = event.getPlayer();
+            int efficiencyLvl = 0;
+            ItemStack itemInHand = player.getInventory().getItemInMainHand();
+            if (itemInHand.containsEnchantment(Enchantment.DIG_SPEED)) {
+                efficiencyLvl = itemInHand.getEnchantmentLevel(Enchantment.DIG_SPEED);
+            }
+
+            if (efficiencyLvl < getMinEfficiencyLvl()) {
+                event.setCancelled(true);
+                player.sendMessage(CataMines.PREFIX + ChatColor.translateAlternateColorCodes('&', CataMines.getInstance().getDefaultString("Tool-Too-Weak")
+                        .replaceAll("%level%", String.valueOf(minEfficiencyLvl))));
+                return;
+            }
+        }
+
+        blockCount--;
+
+        if (warnHotbar && (resetMode == CataMineResetMode.PERCENTAGE || resetMode == CataMineResetMode.TIME_PERCENTAGE)) {
+            broadcastHotbar();
+        }
+
+        if (event.getPlayer().getGameMode().equals(GameMode.CREATIVE)) return;
+
+        boolean autoInv = CataMines.getInstance().isAutoInvEnabled();
+        Player player = event.getPlayer();
+        Location location = event.getBlock().getLocation();
+
+        // When auto-inv is on, always suppress the vanilla block drop so we can
+        // redirect everything into the player's inventory ourselves.
+        if (autoInv) {
+            event.setDropItems(false);
+        }
+
+        // Get fortune level from the player's tool
+        ItemStack tool = player.getInventory().getItemInMainHand();
+        int fortuneLevel = tool.containsEnchantment(Enchantment.LOOT_BONUS_BLOCKS) 
+                ? tool.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS) 
+                : 0;
+
+        // Check whether this block has a matching CataMines composition entry with a loot table.
+        boolean handledByLootTable = false;
+        for (CataMineBlock block : blocks) {
+            if (block.getLootTable().isEmpty() || !block.getBlockData().equals(event.getBlock().getBlockData())) {
+                continue;
+            }
+
+            handledByLootTable = true;
+
+            // Suppress vanilla drops when a custom loot table completely replaces them.
+            if (!block.isAddLootTable()) {
+                event.setDropItems(false);
+            }
+
+            for (CataMineLootItem lootItem : block.getLootTable()) {
+                ItemStack item = lootItem.getItem().clone();
+                double chance = lootItem.getChance();
+                double r1 = random.nextDouble() * 100;
+
+                if (chance < r1) {
+                    continue;
+                }
+
+                // Apply fortune to ALL loot items (not just those with fortune flag)
+                if (fortuneLevel > 0) {
+                    item.setAmount(lootItem.getDropCount(fortuneLevel));
+                }
+
+                if (autoInv) {
+                    Map<Integer, ItemStack> overflow = player.getInventory().addItem(item);
+                    overflow.forEach((slot, leftover) ->
+                            location.getWorld().dropItemNaturally(location, leftover));
+                } else {
+                    location.getWorld().dropItemNaturally(location, item);
+                }
+            }
+        }
+
+        // Handle vanilla drops - fortune is automatically applied by Bukkit's getDrops(tool) method
+        if (autoInv && !handledByLootTable) {
+            // When auto-inv is on and no custom loot table handled this block,
+            // collect the vanilla drops manually (with fortune applied) and push them into the inventory.
+            Collection<ItemStack> vanillaDrops = event.getBlock().getDrops(tool);
+            for (ItemStack drop : vanillaDrops) {
+                Map<Integer, ItemStack> overflow = player.getInventory().addItem(drop);
+                overflow.forEach((slot, leftover) ->
+                        location.getWorld().dropItemNaturally(location, leftover));
+            }
+        } else if (!autoInv && !handledByLootTable) {
+            // When auto-inv is off and no custom loot table, ensure vanilla fortune drops work
+            // Vanilla Minecraft will handle drops naturally with fortune applied
+            // No action needed - setDropItems(false) was never called
+        }
+    }
+
+    public void save() {
+        if (file == null) {
+            file = new File(CataMines.getInstance().getDataFolder() + "/mines", name + ".yml");
+            if (!file.exists()) {
+                try {
+                    file.createNewFile();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        if (fileConfig == null) {
+            fileConfig = new YamlConfiguration();
+        }
+        fileConfig.set("Mine", this);
+        try {
+            fileConfig.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save(FileConfig fileConfig) {
+        fileConfig.set("Mine", this);
+        fileConfig.saveConfig();
+    }
+
+    public Location getTeleportLocation() {
+        if (teleportLocation == null) {
+            if (region != null) {
+                return new Location(BukkitAdapter.adapt(region.getWorld()), region.getCenter().getX() + 0.5, region.getMaximumPoint().getY() + 1, region.getCenter().getZ() + 0.5);
+            }
+        }
+
+        return teleportLocation;
+    }
+
+    @Override
+    public CuboidCataMine clone() {
+        return (CuboidCataMine) super.clone();
+    }
+
+    @Override
+    public long getTotalBlocks() {
+        return region.getVolume();
+    }
+
+    @Override
+    public double getRemainingBlocksPer() {
+        return Math.round(((double) getBlockCount() / (double) getTotalBlocks()) * 10000d) / 100d;
+    }
+
+    public void resetFiles() {
+        file = null;
+        fileConfig = null;
+    }
+}

--- a/src/main/java/de/c4t4lysm/catamines/utils/mine/placeholders/CataMinePlaceHolders.java
+++ b/src/main/java/de/c4t4lysm/catamines/utils/mine/placeholders/CataMinePlaceHolders.java
@@ -1,0 +1,88 @@
+package de.c4t4lysm.catamines.utils.mine.placeholders;
+
+import de.c4t4lysm.catamines.CataMines;
+import de.c4t4lysm.catamines.schedulers.MineManager;
+import de.c4t4lysm.catamines.utils.Utils;
+import de.c4t4lysm.catamines.utils.mine.AbstractCataMine;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+public class CataMinePlaceHolders extends PlaceholderExpansion {
+
+    private final CataMines plugin;
+
+    public CataMinePlaceHolders(CataMines plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "catamines";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return plugin.getDescription().getAuthors().toString();
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String identifier) {
+        int mineIndex = 1;
+
+        String[] args = identifier.split("_");
+        if (args.length <= 1) {
+            if (args[0].equalsIgnoreCase("prefix")) {
+                return plugin.getConfig().getString("prefix", "&6[&bCata&aMines&6] &7");
+            } else {
+                return null;
+            }
+        }
+
+        AbstractCataMine cataMine = MineManager.getInstance().getMine(args[mineIndex]);
+        if (cataMine == null) {
+            return plugin.getLangString("Error-Messages.Mine.Not-Exist");
+        }
+
+        if (!cataMine.isRunnable()) {
+            return "inactive";
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "countdown":
+            case "time":
+                return Utils.secondsToTimeFormat(cataMine.getCountdown());
+            case "remainingseconds":
+                return String.valueOf(cataMine.getCountdown());
+            case "totalblocks":
+                return String.valueOf(cataMine.getTotalBlocks());
+            case "remainingblocks":
+                return String.valueOf(cataMine.getBlockCount());
+            case "minedblocks":
+                return String.valueOf(cataMine.getMinedBlocks());
+            case "remainingblockspercentage":
+            case "remainingblocksper":
+                return String.valueOf(cataMine.getRemainingBlocksPer());
+            case "resetpercentage":
+                return String.valueOf(cataMine.getResetPercentage());
+            case "timestring":
+                return cataMine.getFormattedTimeString();
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Customize the prefix of the plugin
-prefix: "&6[&bCata&aMines&6]"
+prefix: "&6[&bCata&aMines&6] &7"
 
 # Should the plugin update you about newer versions?
 announceUpdate: true

--- a/src/main/resources/messages_cn.yml
+++ b/src/main/resources/messages_cn.yml
@@ -1,0 +1,332 @@
+Time:
+  Seconds: "秒"
+  Second: "秒"
+  Minutes: "分钟"
+  Minute: "分钟"
+  Hours: "小时"
+  Hour: "小时"
+
+GUI:
+  Universal:
+    Previous-Page:
+      Name: "&6&l上一个页"
+      Lore:
+        - ""
+        - "&7打开上一页"
+    Next-Page:
+      Name: "&6&l下一页"
+      Lore:
+        - ""
+        - "&7打开下一页"
+    Close:
+      Name: "&4&l关闭"
+      Lore:
+        - ""
+        - "&7关闭菜单"
+    Back-To-Mine-Menu:
+      Name: "&6&l返回"
+      Lore:
+        - ""
+        - "&7返回菜单"
+    Back-To-Composition-Menu:
+      Name: "&6&l返回"
+      Lore:
+        - ""
+        - "&7返回菜单"
+    Back-To-Block-Menu:
+      Name: "&6&l返回"
+      Lore:
+        - ""
+        - "&7返回方块菜单"
+    Increase-By: "&a增加 %number%"
+    Decrease-By: "&c减少 %number%"
+  Mine-List-Menu:
+    Title: "&b矿场"
+  Mine-Menu:
+    Title: "&b%mine%"
+    Items:
+      Configure-Composition:
+        Name: "&6配置组合"
+        Lore:
+          - "&b配置组合: &c%chance%%"
+      Configure-Delay:
+        Name: "&6配置重置延迟"
+        Lore:
+          - "&b重置延迟: &c%delay%s"
+          - "&b重置百分比: &c%percentage%%"
+          - ""
+          - "&f右键单击以切换模式"
+      Configure-Percentage:
+        Name: "&6配置重置百分比"
+        Lore:
+          - "&b重置百分比: &c%percentage%%"
+          - "&b重置延迟: &c%delay%s"
+          - ""
+          - "&f右键单击以切换模式"
+      Warn:
+        Active:
+          Name: "&a重置时警告"
+        Inactive:
+          Name: "&7不会在重置时发出警告"
+        Lore:
+          - "&b如果启用警告重置，则选中"
+      Warn-Global:
+        Active:
+          Name: "&a全局警告"
+        Inactive:
+          Name: "&7不会全局发出警告"
+        Lore:
+          - "&b如果启用全局警告，则选中"
+      Warn-Hotbar:
+        Active:
+          Name: "&a在血条中显示秒数"
+        Inactive:
+          Name: "&7不会血条中显示秒数"
+        Lore:
+          - "&b如果启用血条中显示秒数，则选中"
+      Teleport-Players:
+        Active:
+          Name: "&a将玩家传送到重置状态"
+        Inactive:
+          Name: "&7不会在重置时传送玩家"
+        Lore:
+          - "&b如果启用重置时传送玩家，则选中"
+      Teleport-Players-To-Reset-Location:
+        Active:
+          Name: "&a将玩家传送到重置位置"
+        Inactive:
+          Name: "&7将玩家传送到矿区上"
+        Lore:
+          - "&b选择矿区玩家是否应该传送"
+          - "&b重置位置而不是仅仅在顶部"
+          - "&6&7确保您有一个重置位置"
+          - "&7使用 /cm setresettp"
+          - "&7激活，传送玩家才能生效"
+      Replace-Mode:
+        Active:
+          Name: "&a更换模式开启"
+        Inactive:
+          Name: "&7替换模式关闭"
+        Lore:
+          - "&b如果矿区只替换 &a空气 &b为矿物，则选中"
+      Efficiency-Lvl:
+        Name: "&6配置最小效率 l"
+        Lore:
+          - "&b打破区块的最低效率水平: &c%level%"
+          - ""
+          - "&6&l注意: &b管理员获得权限的许可"
+          - "&bcatamines.break 可以绕开这个"
+      Warn-Distance:
+        Name: "&6配置警告距离"
+        Lore:
+          - "&b警告距离: &c%distance%"
+      Reset-Mine:
+        Name: "&c重置矿场"
+      Teleport:
+        Name: "&5传送到矿场"
+        Lore:
+          - "&b把你传送到矿场"
+      Delete:
+        Name: "&4&l删除矿场"
+      Start-Stop:
+        Active:
+          Name: "&a矿场开启"
+        Inactive:
+          Name: "&7矿场关闭"
+        Lore:
+          - "&b如果应该自动重置，则选中开启"
+      Back:
+        Name: "&4&l返回"
+        Lore:
+          - ""
+          - "&7返回矿场菜单。"
+      Running:
+        Active:
+          Name: "&a矿场目前正在运行"
+          Lore:
+            - "&7如果矿场当前正在运行，则显示"
+            - "&7如果它不是，那么它将显示关闭。"
+        Inactive:
+          Name: "&7我的没有运行是因为:"
+          Reasons:
+            Invalid-Region: "&c它的区域无效"
+            Stopped: "&c它被停止了"
+            No-Composition: "&c它没有成分"
+            Invalid-Delay: "&c它的重置延迟是: %delay%"
+  Composition-Menu:
+    Title: "&b地图: &c%chance%%"
+    Items:
+      Composition-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&b生成概率: &c%chance%%"
+          - ""
+          - "&a左键来配置哦"
+      Info:
+        Name: "&6信息:"
+        Lore:
+          - "&a添加物品 右键/左键"
+          - "&a在你的库存中点击它们。"
+          - ""
+          - "&c右键移除物品"
+          - "&c移除全部"
+  Composition-Block-Menu:
+    Title: "&b方块概率: &c%blockChance%% / %compChance%%"
+    Items:
+      Current-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&b方块概率: &c%blockChance%%"
+          - "&b合成概率: &c%compChance%%"
+      Change-Table:
+        Name: "&6更换战利品表"
+      Configure-Table:
+        Name: "&6配置战利品表的掉落概率"
+      Add-Loot-Table:
+        Active:
+          Name: "&a战利品表将添加到默认下列表的顶部"
+        Inactive:
+          Name: "&7战利品表覆盖默认列表。"
+        Lore:
+          - "&b选择如果您想要覆盖掉落概率。"
+          - "&b此块，或如果您想添加某些。"
+          - "&b掉落在其默认下降的基础上。"
+          - "&6&l注意: &b战利品桌是空的，这个会变为"
+          - "&b忽视"
+  Change-Loot-Table-Menu:
+    Title: "&b将物品插入战利品表"
+    Items:
+      Save-Table:
+        Name: "&a保存战利品表"
+        Message: "&a保存了战利品表。"
+  Loot-Table-List-Menu:
+    Title: "&b配置物品丢弃概率"
+    Items:
+      Drop-Item:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - ""
+          - "&b丢弃概率: &c%chance%%"
+  Configure-Item-Drop-Chances-Menu:
+    Title: "&b丢弃概率: &c%itemChance%/100%"
+    Items:
+      Current-Item: "%！不可改变！内部材料名称%"
+  Reset-Delay-Menu:
+    Title: "&b当前延迟: &c%delay%"
+    Items:
+      Current-Delay:
+        Name: "&b当前延迟 &c%delay%"
+      Switch:
+        Name: "&6开/关模式"
+        Lore:
+          - ""
+          - "&b将电流模式切换到 &6TIME"
+  Reset-Percentage-Menu:
+    Title: "&b当前百分比: &c%percentage%%"
+    Items:
+      Current-Percentage:
+        Name: "&b当前百分比: &c%percentage%"
+      Switch:
+        Name: "&6开/关模式"
+        Lore:
+          - ""
+          - "&b将电流模式切换到 &6延迟"
+  Efficiency-Menu:
+    Title: "&b最小效率等级: &c%level%"
+    Items:
+      Current-Level:
+        Name: "&b最低挖矿效率等级: &c%level%"
+        Lore:
+          - "&b挖掘矿物的最低效率等级: &c%level%"
+          - ""
+          - "&6&l注意: &b你需要获得管理员的许可"
+          - "&bcatamines.break 可以绕开这个!"
+  Warn-Distance-Menu:
+    Title: "&b警告距离: &c%distance%"
+    Items:
+      Current-Distance:
+        Name: "&a电流距离: &c%distance%"
+
+Commands:
+  Create: "矿场 &b%mine% &7创建."
+  Delete: "矿场 &b%mine% &7删除."
+  Reset-Mode: "重置 &b%mine% 于 &a%mode%&7."
+  Delay: "将重置延迟设置为 &a%seconds% &7秒."
+  Reset-Percentage: "&b%mine% &7现在重设有 &a%percentage%% &7方块左键"
+  Set:
+    Success: "&b%material% &7设为 &a%mine%&7. 你有 &6%remainingChance%% &7剩下的。"
+    Error: "%chance-over-100%. 你有 &6%remainingChance%% &7剩下的。"
+  Unset:
+    Clear: "矿区 &a%mine% &7已被清除"
+    Remove:
+      Success: "&b%material% &7被移除了。你有 &a%remainingChance%% &7剩下的。"
+      Error: "&b%material% &7不在...组成中 %mine%&7. 你有 &a%remainingChance%% &7剩下的。"
+  Reset: "矿区已经被重置了。"
+  Teleport:
+    Self: "传送至 &b%mine%."
+    Other: "传送玩家 &6%player% &7至 &b%mine%"
+  Set-Teleport: "固定传送 &b%mine% 的传送位置."
+  Set-Reset-Teleport: "设置重置传送位置 &b%mine%. &7还将TelportPlayersToResetLocation设置为&a开启"
+  Flag:
+    Move-Region: "移动区域 &c%mine%."
+    Rename: "命名 &b%oldmine% &7为 &a%newmine%."
+    Replace-Mode: "设置模式 &b%mine% &7至 &a%arg%."
+    Teleport-Players: "传送玩家 &b%mine% &7至 &a%arg%."
+    Warn:
+      Warn-Hotbar: "警告血条 &b%mine% &7设置至 &a%arg%."
+      Warn-Enable: "警告开启 &b%mine% &7设置至 &a%arg%."
+      Warn-Global: "全局警告 &b%mine% &7设置至 &a%arg%."
+      Warn-Message: "&a更新的警告消息。"
+      Reset-Message: "&a更新的重置消息。"
+      Warn-Distance: "警告距离 &b%mine% &7设置至 &a%arg%."
+      Warn-Seconds: "&a更新的警告秒。"
+  Start: "&a开启矿区 %mine%."
+  Stop: "&c关闭矿区 %mine%."
+  Start-Tasks: "&a开启了全部的矿区"
+  Stop-Tasks: "&c关闭了全部的矿区"
+  Synced: "&aSynced all mines"
+  Toggle-Auto-Inv:
+    Enabled: "&a自动拾取已&2启用&a。矿区掉落物将直接进入玩家背包。"
+    Disabled: "&c自动拾取已&4禁用&c。矿区掉落物将正常掉落在地上。"
+  Reload:
+    All: "&a插件重载成功."
+    Mines: "&a矿区重载成功."
+    Config: "&a配置重载成功."
+    Messages: "&a语言文件重载成功."
+    Properties: "&a属性已重载成功."
+
+Error-Messages:
+  No-Permission: "&c你没有权限这样做哦!"
+  Only-Players: "&c只有玩家才能执行此命令。!"
+  Unknown-Command: "未知的命令."
+  Unknown-Flag: "未知的标志."
+  Player-Not-Found: "玩家 &6%player% &7找不到！"
+  Mine:
+    Incomplete-Region: "你必须选择一个区域！"
+    Not-Exist: "工具不存在!"
+    Exist: "工具不存在！"
+    Cant-Reset: "不能重置矿场"
+    Material-Not-Found: "材料没找到！"
+    Not-Number: "你的概率一定是数字！"
+    Not-Percentage: "你的概率一定要是百分比！"
+    Invalid-Chance: "你的概率必须在0到100%之间！"
+    Invalid-Range: "您的输入必须在 %start%-%end%之间!"
+    Material-Not-Solid: "材料必须是实心的块！"
+    Invalid-Block-Configuration: "无效的方块配置！"
+    Invalid-Boolean: "你的最后一个论点必须是正确的还是错误的！"
+    Teleport-Error: "位置不存在！"
+    Block-Not-In-Composition: "方块不在地图中"
+    Invalid-Region: "&c区域无效！"
+    Material-In-Composition: "材料已经在合成成功了！"
+    Chance-Over-100: "概率超过了100%！"
+  GUI:
+    Mine-Deleted: "从矿区工具菜单上踢出！"
+    Block-Deleted: "从方块菜单上踢出！"
+    Loot-Table-Change: "战利品改变了！"
+    First-Page: "你已经在第一页了"
+    Last-Page: "你在最后一页"
+    Mine-Doesnt-Exist: "&c你想打开的矿区已经不存在了！"

--- a/src/main/resources/messages_custom.yml
+++ b/src/main/resources/messages_custom.yml
@@ -1,0 +1,409 @@
+Time:
+  Seconds: "seconds"
+  Second: "second"
+  Minutes: "minutes"
+  Minute: "minute"
+  Hours: "hours"
+  Hour: "hour"
+
+GUI:
+  Universal:
+    Previous-Page:
+      Name: "&6&lPrevious Page"
+      Lore:
+        - ""
+        - "&7Opens the previous page if there is one"
+    Next-Page:
+      Name: "&6&lNext Page"
+      Lore:
+        - ""
+        - "&7Opens the next page if there is one"
+    Close:
+      Name: "&4&lClose"
+      Lore:
+        - ""
+        - "&7Closes the menu"
+    Back-To-Mine-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to mine menu"
+    Back-To-Composition-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to composition menu"
+    Back-To-Block-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to block menu"
+    Increase-By: "&aIncrease by %number%"
+    Decrease-By: "&cDecrease by %number%"
+  Mine-List-Menu:
+    Title: "&bMines"
+  Mine-Menu:
+    Title: "&b%mine%"
+    Items:
+      Configure-Composition:
+        Name: "&6Configure composition"
+        Lore:
+          - ""
+          - "&bComposition: &c%chance%%"
+      Configure-Delay:
+        Name: "&6Configure reset delay"
+        Lore:
+          - "&fReset by delay"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Configure-Percentage:
+        Name: "&6Configure reset percentage"
+        Lore:
+          - "&fReset by percentage"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Configure-TimePercentage:
+        Name: "&6TIME-PERCENTAGE"
+        Lore:
+          - "&fReset by delay and percentage"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Flag-Menu:
+        Name: "&6Configure flags"
+        Lore:
+          - ""
+          - "&eWarns: &f%warn%"
+          - "  &eGlobal: &f%global%"
+          - "  &eActionbar: &f%actionbar%"
+          - "  &eDistance: &c%warndistance%"
+          - "&eTeleports: &f%teleports%"
+          - "  &eTo resettp: &f%resettp%"
+          - "&eReplaces: &f%replacemode%"
+      Efficiency-Lvl:
+        Name: "&6Efficiency Lvl"
+        Lore:
+          - ""
+          - "&bLevel: &c%level%"
+          - ""
+          - "&fEff. Lvl required to break"
+          - "&fmine blocks."
+          - ""
+          - "&fPermission &6catamines.break"
+          - "&fbypasses this check!"
+      Reset-Mine:
+        Name: "&cReset mine"
+      Teleport:
+        Name: "&5Teleport to mine"
+        Lore:
+          - "&bTeleports you to the mine"
+      Delete:
+        Name: "&4&lDelete mine"
+      Start-Stop:
+        Active:
+          Name: "&aMine turned on"
+        Inactive:
+          Name: "&7Mine turned off"
+        Lore:
+          - "&bSelect if mine should reset automatically"
+      Back:
+        Name: "&4&lBack"
+        Lore:
+          - ""
+          - "&7Goes back to the mine menu"
+      Running:
+        Active:
+          Name: "&aMine is currently running"
+          Lore:
+            - "&7Displays if the mine is currently running."
+            - "&7If its not, then it will display why not."
+        Inactive:
+          Name: "&7Mine is not running because:"
+          Reasons:
+            Invalid-Region: "&cIts region is invalid"
+            Stopped: "&cIt is stopped"
+            No-Composition: "&cIt has no composition"
+            Invalid-Delay: "&cIts reset delay is %delay%"
+  Composition-Menu:
+    Title: "&bComposition: &c%chance%%"
+    Items:
+      Composition-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bSpawning chance: &c%chance%%"
+          - ""
+          - "&aLeft click me to configure"
+      Info:
+        Name: "&6Info:"
+        Lore:
+          - "&aAdd items by left/right"
+          - "&aclicking them in your inventory."
+          - ""
+          - "&cRemove items by right clicking"
+          - "&cthem in the composition list"
+  Composition-Block-Menu:
+    Title: "&bBlock chance: &c%blockChance%% / %compChance%%"
+    Items:
+      Current-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bBlock chance: &c%blockChance%%"
+          - "&bComposition chance: &c%compChance%%"
+      Change-Table:
+        Name: "&6Change loot table"
+      Configure-Table:
+        Name: "&6Configure drop chances of loot table"
+      Add-Loot-Table:
+        Active:
+          Name: "&a&lCustom drops are added"
+          Lore:
+            - ""
+            - "&fCustom drops are added on top"
+            - "&fof the default drops"
+        Inactive:
+          Name: "&7Custom drops override"
+          Lore:
+            - ""
+            - "&fDefault drops get cleared."
+            - "&fBlock only drops custom drops."
+  Change-Loot-Table-Menu:
+    Title: "&bInsert items into loot table"
+    Items:
+      Save-Table:
+        Name: "&aSave loot table"
+        Message: "&aSaved loot table."
+  Loot-Table-List-Menu:
+    Title: "&bConfigure item drop chances"
+    Items:
+      Drop-Item:
+        Name: "!unchangeable! internal material name"
+        Lore:
+          - ""
+          - "&bDrop chance: &c%chance%%"
+  Configure-Item-Drop-Chances-Menu:
+    Title: "&bDrop chance: &c%itemChance%/100%"
+    Items:
+      Current-Item: "!unchangeable! internal item"
+      Fortune:
+        Active:
+          Name: "&a&lFortune"
+          Lore:
+            - ""
+            - "&fFortune level will influence"
+            - "&fthe drop amount of this item"
+        Inactive:
+          Name: "&7Fortune"
+          Lore:
+            - ""
+            - "&fItem will not be"
+            - "&finfluenced by fortune"
+  Reset-Delay-Menu:
+    Title: "&bCurrent delay: &c%delay%"
+    Items:
+      Current-Delay:
+        Name: "&bCurrent delay: &c%delay%"
+      Switch:
+        Name: "&6Switch page"
+        Lore:
+          - ""
+          - "&bSwitch page to &6PERCENTAGE"
+  Reset-Percentage-Menu:
+    Title: "&bCurrent percentage: &c%percentage%%"
+    Items:
+      Current-Percentage:
+        Name: "&bCurrent percentage: &c%percentage%"
+      Switch:
+        Name: "&6Switch page"
+        Lore:
+          - ""
+          - "&bSwitch page to &6TIME"
+  Flags-Menu:
+    Title: "&6&lSetup mine flags"
+    Items:
+      Warn:
+        Active:
+          Name: "&a&lWarn"
+          Lore:
+            - ""
+            - "&fMine now warns on specified reset"
+            - "&fseconds and on reset"
+        Inactive:
+          Name: "&7Warn"
+          Lore:
+            - ""
+            - "&fMine does not warn"
+      Warn-Global:
+        Active:
+          Name: "&a&lWarn globally"
+          Lore:
+            - ""
+            - "&fIf &a&l'Warn' &fis enabled"
+            - "&fit now warns globally"
+        Inactive:
+          Name: "&7Warn globally"
+          Lore:
+            - ""
+            - "&fMine does not warn globally"
+      Warn-Hotbar:
+        Active:
+          Name: "&a&lBroadcast Actionbar"
+          Lore:
+            - ""
+            - "&fDisplay mine information in"
+            - "&fplayers actionbar"
+        Inactive:
+          Name: "&7Broadcast Actionbar"
+          Lore:
+            - ""
+            - "&fDisplay mine information in"
+            - "&fplayers actionbar"
+      Teleport-Players:
+        Active:
+          Name: "&a&lTeleport players"
+          Lore:
+            - ""
+            - "&fActivates teleports on reset"
+            - "&fYou can choose tp on top or"
+            - "&fto reset location of mine"
+        Inactive:
+          Name: "&7Teleport players"
+          Lore:
+            - ""
+            - "&fActivates teleports on reset"
+            - "&fYou can choose tp on top or"
+            - "&fto reset location of mine"
+      Teleport-Players-To-Reset-Location:
+        Active:
+          Name: "&aTeleport location"
+          Lore:
+            - ""
+            - "&fCurrently teleports to reset"
+            - "&flocation if specified by using"
+            - "&f/cm setresettp <mine>"
+        Inactive:
+          Name: "&2Teleport location"
+          Lore:
+            - ""
+            - "&fCurrently teleports to the"
+            - "&ftop of the mine on reset"
+      Replace-Mode:
+        Active:
+          Name: "&a&lReplaces air"
+          Lore:
+            - ""
+            - "&fOnly resets empty blocks of the mine"
+        Inactive:
+          Name: "&7Replaces all"
+          Lore:
+            - ""
+            - "&fResets all blocks of the mine"
+      Warn-Distance:
+        Name: "&6Configure warn distance"
+        Lore:
+          - "&bWarn distance: &c%distance%"
+  Efficiency-Menu:
+    Title: "&bLevel: &c%level%"
+    Items:
+      Current-Level:
+        Name: "&bEfficiency Lvl: &c%level%"
+        Lore:
+          - ""
+          - "&fPermission &6catamines.break"
+          - "&fbypasses this check!"
+  Warn-Distance-Menu:
+    Title: "&bWarn distance: &c%distance%"
+    Items:
+      Current-Distance:
+        Name: "&bCurrent distance: &c%distance%"
+
+Commands:
+  Create: "Mine &b%mine% &7has been created."
+  Delete: "Mine &b%mine% &7has been deleted."
+  Reset-Mode: "Set reset mode of &b%mine% &7to &a%mode%&7."
+  Delay: "Set reset delay to &a%seconds% &7seconds."
+  Reset-Percentage: "&b%mine% &7now resets when there is &a%percentage%% &7of blocks left"
+  Set:
+    Success: "&b%material% &7set for &a%mine%&7. You have &6%remainingChance%% &7left over."
+    Error: "%chance-over-100%. You have &6%remainingChance%% &7left over."
+  Unset:
+    Clear: "Composition of &a%mine% &7has been cleared"
+    Remove:
+      Success: "&b%material% &7was removed. You have &a%remainingChance%% &7left over."
+      Error: "&b%material% &7was not in the composition of %mine%&7. You have &a%remainingChance%% &7left over."
+  Reset: "Mine has been reset."
+  Teleport:
+    Self: "Teleported to &b%mine%."
+    Other: "Teleported &6%player% &7to &b%mine%"
+  Set-Teleport: "Set teleport of &b%mine%."
+  Set-Reset-Teleport: "Set reset teleport of &b%mine%. &7Also set teleportPlayersToResetLocation to &atrue"
+  Flag:
+    Move-Region: "Moved region of &c%mine%."
+    Rename: "Renamed &b%oldmine% &7to &a%newmine%."
+    Replace-Mode: "Set replace mode of &b%mine% &7to &a%arg%."
+    Teleport-Players: "Teleport players of &b%mine% &7set to &a%arg%."
+    Warn:
+      Warn-Hotbar: "Warns of &b%mine% &7set to &a%arg%."
+      Warn-Enable: "Warns of &b%mine% &7set to &a%arg%."
+      Warn-Global: "Global warns of &b%mine% &7set to &a%arg%."
+      Warn-Message: "&aUpdated warn message."
+      Reset-Message: "&aUpdated reset message."
+      Warn-Distance: "Warn distance of &b%mine% &7set to &a%arg%."
+      Warn-Seconds: "&aUpdated warn seconds."
+  Start: "&aStarted %mine%."
+  Stop: "&cStopped %mine%."
+  Start-Tasks: "&aStarted all mine tasks"
+  Stop-Tasks: "&cStopped all mine tasks"
+  Sync: "&aSynced all mines"
+  Toggle-Auto-Inv:
+    Enabled: "&aAuto-inventory is now &2enabled&a. Mine drops will go directly into player inventories."
+    Disabled: "&cAuto-inventory is now &4disabled&c. Mine drops will fall to the ground normally."
+  Reload:
+    All: "&aPlugin has been reloaded."
+    Mines: "&aMines have been reloaded."
+    Config: "&aConfig has been reloaded."
+    Messages: "&aMessages have been reloaded."
+    Properties: "&aProperties have been reloaded."
+
+Error-Messages:
+  No-Permission: "&cYou do not have the permissions to do that!"
+  Only-Players: "&cOnly players may execute this command!"
+  Unknown-Command: "Unknown command."
+  Unknown-Flag: "Unknown flag."
+  Player-Not-Found: "Player &6%player% &7not found!"
+  Mine:
+    Incomplete-Region: "You must select a region!"
+    Not-Exist: "Mine does not exist!"
+    Exist: "Mine already exists!"
+    Cant-Reset: "Can't reset mine!"
+    Material-Not-Found: "Material not found!"
+    Not-Number: "Your chance must be a number!"
+    Not-Percentage: "Your chance must be a percentage!"
+    Invalid-Chance: "Your chance must be between 0 and 100%!"
+    Invalid-Range: "Your input must be between %start%-%end%!"
+    Material-Not-Solid: "Material must be a solid block!"
+    Invalid-Block-Configuration: "Invalid block configuration!"
+    Invalid-Boolean: "Your last argument must be either true or false!"
+    Teleport-Error: "Location does not exist!"
+    Block-Not-In-Composition: "Block is not in composition"
+    Invalid-Region: "&cRegion is invalid!"
+    Material-In-Composition: "Material is already in composition!"
+    Chance-Over-100: "Chance would be over 100%"
+  GUI:
+    Mine-Deleted: "Kicked out of mine menu!"
+    Block-Deleted: "Kicked out of block menu!"
+    Loot-Table-Change: "Loot table changed!"
+    First-Page: "You are already on the first page"
+    Last-Page: "You are on the last page"
+    Mine-Doesnt-Exist: "&cThe mine you tried to open doesn't exist anymore!"

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -1,0 +1,426 @@
+Time:
+  Seconds: "seconds"
+  Second: "second"
+  Minutes: "minutes"
+  Minute: "minute"
+  Hours: "hours"
+  Hour: "hour"
+
+GUI:
+  Universal:
+    Previous-Page:
+      Name: "&6&lPrevious Page"
+      Lore:
+        - ""
+        - "&7Opens the previous page if there is one"
+    Next-Page:
+      Name: "&6&lNext Page"
+      Lore:
+        - ""
+        - "&7Opens the next page if there is one"
+    Close:
+      Name: "&4&lClose"
+      Lore:
+        - ""
+        - "&7Closes the menu"
+    Back-To-Mine-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to mine menu"
+    Back-To-Composition-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to composition menu"
+    Back-To-Block-Menu:
+      Name: "&6&lBack"
+      Lore:
+        - ""
+        - "&7Goes back to block menu"
+    Increase-By: "&aIncrease by %number%"
+    Decrease-By: "&cDecrease by %number%"
+  Mine-List-Menu:
+    Title: "&bMines"
+  Mine-Menu:
+    Title: "&b%mine%"
+    Items:
+      Configure-Composition:
+        Name: "&6Configure composition"
+        Lore:
+          - ""
+          - "&bComposition: &c%chance%%"
+      Configure-Delay:
+        Name: "&6Configure reset delay"
+        Lore:
+          - "&fReset by delay"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Configure-Percentage:
+        Name: "&6Configure reset percentage"
+        Lore:
+          - "&fReset by percentage"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Configure-TimePercentage:
+        Name: "&6TIME-PERCENTAGE"
+        Lore:
+          - "&fReset by delay and percentage"
+          - ""
+          - "&bReset delay: &c%delay%"
+          - "&bReset percentage: &c%percentage%"
+          - ""
+          - "&a&lRight click to switch modes"
+      Flag-Menu:
+        Name: "&6Configure flags"
+        Lore:
+          - ""
+          - "&eWarns: &f%warn%"
+          - "  &eGlobal: &f%global%"
+          - "  &eActionbar: &f%actionbar%"
+          - "  &eDistance: &c%warndistance%"
+          - "&eTeleports: &f%teleports%"
+          - "  &eTo resettp: &f%resettp%"
+          - "&eReplaces: &f%replacemode%"
+      Efficiency-Lvl:
+        Name: "&6Efficiency Lvl"
+        Lore:
+          - ""
+          - "&bLevel: &c%level%"
+          - ""
+          - "&fEff. Lvl required to break"
+          - "&fmine blocks."
+          - ""
+          - "&fPermission &6catamines.break"
+          - "&fbypasses this check!"
+      Reset-Mine:
+        Name: "&cReset mine"
+      Reset-Mode:
+        Time:
+          Name: "&6Reset Mode: &bTIMER"
+        Percentage:
+          Name: "&6Reset Mode: &bPERCENTAGE"
+        Both:
+          Name: "&6Reset Mode: &aBOTH"
+        Lore:
+          - ""
+          - "&7Click to cycle to the next mode"
+          - ""
+          - "&eTIMER &7- resets on a countdown"
+          - "&ePERCENTAGE &7- resets when blocks mined"
+          - "&eBOTH &7- resets on either condition"
+      Teleport:
+        Name: "&5Teleport to mine"
+        Lore:
+          - "&bTeleports you to the mine"
+      Delete:
+        Name: "&4&lDelete mine"
+      Start-Stop:
+        Active:
+          Name: "&aMine turned on"
+        Inactive:
+          Name: "&7Mine turned off"
+        Lore:
+          - "&bSelect if mine should reset automatically"
+      Back:
+        Name: "&4&lBack"
+        Lore:
+          - ""
+          - "&7Goes back to the mine menu"
+      Running:
+        Active:
+          Name: "&aMine is currently running"
+          Lore:
+            - "&7Displays if the mine is currently running."
+            - "&7If its not, then it will display why not."
+        Inactive:
+          Name: "&7Mine is not running because:"
+          Reasons:
+            Invalid-Region: "&cIts region is invalid"
+            Stopped: "&cIt is stopped"
+            No-Composition: "&cIt has no composition"
+            Invalid-Delay: "&cIts reset delay is %delay%"
+  Composition-Menu:
+    Title: "&bComposition: &c%chance%%"
+    Items:
+      Composition-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bSpawning chance: &c%chance%%"
+          - ""
+          - "&aLeft click me to configure"
+      Info:
+        Name: "&6Info:"
+        Lore:
+          - "&aAdd items by left/right"
+          - "&aclicking them in your inventory."
+          - ""
+          - "&cRemove items by right clicking"
+          - "&cthem in the composition list"
+  Composition-Block-Menu:
+    Title: "&bBlock chance: &c%blockChance%% / %compChance%%"
+    Items:
+      Current-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bBlock chance: &c%blockChance%%"
+          - "&bComposition chance: &c%compChance%%"
+      Change-Table:
+        Name: "&6Change loot table"
+      Configure-Table:
+        Name: "&6Configure drop chances of loot table"
+      Add-Loot-Table:
+        Active:
+          Name: "&a&lCustom drops are added"
+          Lore:
+            - ""
+            - "&fCustom drops are added on top"
+            - "&fof the default drops"
+        Inactive:
+          Name: "&7Custom drops override"
+          Lore:
+            - ""
+            - "&fDefault drops get cleared."
+            - "&fBlock only drops custom drops."
+  Change-Loot-Table-Menu:
+    Title: "&bInsert items into loot table"
+    Items:
+      Save-Table:
+        Name: "&aSave loot table"
+        Message: "&aSaved loot table."
+  Loot-Table-List-Menu:
+    Title: "&bConfigure item drop chances"
+    Items:
+      Drop-Item:
+        Name: "!unchangeable! internal material name"
+        Lore:
+          - ""
+          - "&bDrop chance: &c%chance%%"
+  Configure-Item-Drop-Chances-Menu:
+    Title: "&bDrop chance: &c%itemChance%/100%"
+    Items:
+      Current-Item: "!unchangeable! internal item"
+      Fortune:
+        Active:
+          Name: "&a&lFortune"
+          Lore:
+            - ""
+            - "&fFortune level will influence"
+            - "&fthe drop amount of this item"
+        Inactive:
+          Name: "&7Fortune"
+          Lore:
+            - ""
+            - "&fItem will not be"
+            - "&finfluenced by fortune"
+  Reset-Delay-Menu:
+    Title: "&bCurrent delay: &c%delay%"
+    Items:
+      Current-Delay:
+        Name: "&bCurrent delay: &c%delay%"
+      Switch:
+        Name: "&6Switch page"
+        Lore:
+          - ""
+          - "&bSwitch page to &6PERCENTAGE"
+  Reset-Percentage-Menu:
+    Title: "&bCurrent percentage: &c%percentage%%"
+    Items:
+      Current-Percentage:
+        Name: "&bCurrent percentage: &c%percentage%"
+      Switch:
+        Name: "&6Switch page"
+        Lore:
+          - ""
+          - "&bSwitch page to &6TIME"
+  Flags-Menu:
+    Title: "&6&lSetup mine flags"
+    Items:
+      Warn:
+        Active:
+          Name: "&a&lWarn"
+          Lore:
+            - ""
+            - "&fMine now warns on specified reset"
+            - "&fseconds and on reset"
+        Inactive:
+          Name: "&7Warn"
+          Lore:
+            - ""
+            - "&fMine does not warn"
+      Warn-Global:
+        Active:
+          Name: "&a&lWarn globally"
+          Lore:
+            - ""
+            - "&fIf &a&l'Warn' &fis enabled"
+            - "&fit now warns globally"
+        Inactive:
+          Name: "&7Warn globally"
+          Lore:
+            - ""
+            - "&fMine does not warn globally"
+      Warn-Hotbar:
+        Active:
+          Name: "&a&lBroadcast Actionbar"
+          Lore:
+            - ""
+            - "&fDisplay mine information in"
+            - "&fplayers actionbar"
+        Inactive:
+          Name: "&7Broadcast Actionbar"
+          Lore:
+            - ""
+            - "&fDisplay mine information in"
+            - "&fplayers actionbar"
+      Teleport-Players:
+        Active:
+          Name: "&a&lTeleport players"
+          Lore:
+            - ""
+            - "&fActivates teleports on reset"
+            - "&fYou can choose tp on top or"
+            - "&fto reset location of mine"
+        Inactive:
+          Name: "&7Teleport players"
+          Lore:
+            - ""
+            - "&fActivates teleports on reset"
+            - "&fYou can choose tp on top or"
+            - "&fto reset location of mine"
+      Teleport-Players-To-Reset-Location:
+        Active:
+          Name: "&aTeleport location"
+          Lore:
+            - ""
+            - "&fCurrently teleports to reset"
+            - "&flocation if specified by using"
+            - "&f/cm setresettp <mine>"
+        Inactive:
+          Name: "&2Teleport location"
+          Lore:
+            - ""
+            - "&fCurrently teleports to the"
+            - "&ftop of the mine on reset"
+      Replace-Mode:
+        Active:
+          Name: "&a&lReplaces air"
+          Lore:
+            - ""
+            - "&fOnly resets empty blocks of the mine"
+        Inactive:
+          Name: "&7Replaces all"
+          Lore:
+            - ""
+            - "&fResets all blocks of the mine"
+      Warn-Distance:
+        Name: "&6Configure warn distance"
+        Lore:
+          - "&bWarn distance: &c%distance%"
+  Efficiency-Menu:
+    Title: "&bLevel: &c%level%"
+    Items:
+      Current-Level:
+        Name: "&bEfficiency Lvl: &c%level%"
+        Lore:
+          - ""
+          - "&fPermission &6catamines.break"
+          - "&fbypasses this check!"
+  Warn-Distance-Menu:
+    Title: "&bWarn distance: &c%distance%"
+    Items:
+      Current-Distance:
+        Name: "&bCurrent distance: &c%distance%"
+
+Commands:
+  Create: "Mine &b%mine% &7has been created."
+  Delete: "Mine &b%mine% &7has been deleted."
+  Reset-Mode: "Set reset mode of &b%mine% &7to &a%mode%&7."
+  Set-All-Reset-Mode: "Set reset mode of &a%count% &7mines to &a%mode%&7."
+  Set-All-Mine-Timer: "Set reset timer of &a%count% &7mines to &a%seconds% &7seconds."
+  Set-All-Mine-Percentage: "Set reset percentage of &a%count% &7mines to &a%percentage%%%7."
+  Delay: "Set reset delay to &a%seconds% &7seconds."
+  Reset-Percentage: "&b%mine% &7now resets when there is &a%percentage%% &7of blocks left"
+  Set:
+    Success: "&b%material% &7set for &a%mine%&7. You have &6%remainingChance%% &7left over."
+    Error: "%chance-over-100%. You have &6%remainingChance%% &7left over."
+  Unset:
+    Clear: "Composition of &a%mine% &7has been cleared"
+    Remove:
+      Success: "&b%material% &7was removed. You have &a%remainingChance%% &7left over."
+      Error: "&b%material% &7was not in the composition of %mine%&7. You have &a%remainingChance%% &7left over."
+  Reset: "Mine has been reset."
+  Teleport:
+    Self: "Teleported to &b%mine%."
+    Other: "Teleported &6%player% &7to &b%mine%"
+  Set-Teleport: "Set teleport of &b%mine%."
+  Set-Reset-Teleport: "Set reset teleport of &b%mine%. &7Also set teleportPlayersToResetLocation to &atrue"
+  Flag:
+    Move-Region: "Moved region of &c%mine%."
+    Rename: "Renamed &b%oldmine% &7to &a%newmine%."
+    Replace-Mode: "Set replace mode of &b%mine% &7to &a%arg%."
+    Teleport-Players: "Teleport players of &b%mine% &7set to &a%arg%."
+    Warn:
+      Warn-Hotbar: "Warns of &b%mine% &7set to &a%arg%."
+      Warn-Enable: "Warns of &b%mine% &7set to &a%arg%."
+      Warn-Global: "Global warns of &b%mine% &7set to &a%arg%."
+      Warn-Message: "&aUpdated warn message."
+      Reset-Message: "&aUpdated reset message."
+      Warn-Distance: "Warn distance of &b%mine% &7set to &a%arg%."
+      Warn-Seconds: "&aUpdated warn seconds."
+  Start: "&aStarted %mine%."
+  Stop: "&cStopped %mine%."
+  Start-Tasks: "&aStarted all mine tasks"
+  Stop-Tasks: "&cStopped all mine tasks"
+  Sync: "&aSynced all mines"
+  Toggle-Auto-Inv:
+    Enabled: "&aAuto-inventory is now &2enabled&a. Mine drops will go directly into player inventories."
+    Disabled: "&cAuto-inventory is now &4disabled&c. Mine drops will fall to the ground normally."
+  Reload:
+    All: "&aPlugin has been reloaded."
+    Mines: "&aMines have been reloaded."
+    Config: "&aConfig has been reloaded."
+    Messages: "&aMessages have been reloaded."
+    Properties: "&aProperties have been reloaded."
+
+Error-Messages:
+  No-Permission: "&cYou do not have the permissions to do that!"
+  Only-Players: "&cOnly players may execute this command!"
+  Unknown-Command: "Unknown command."
+  Unknown-Flag: "Unknown flag."
+  Player-Not-Found: "Player &6%player% &7not found!"
+  Mine:
+    Incomplete-Region: "You must select a region!"
+    Not-Exist: "Mine does not exist!"
+    Exist: "Mine already exists!"
+    Cant-Reset: "Can't reset mine!"
+    Material-Not-Found: "Material not found!"
+    Not-Number: "Your chance must be a number!"
+    Not-Percentage: "Your chance must be a percentage!"
+    Invalid-Chance: "Your chance must be between 0 and 100%!"
+    Invalid-Range: "Your input must be between %start%-%end%!"
+    Material-Not-Solid: "Material must be a solid block!"
+    Invalid-Block-Configuration: "Invalid block configuration!"
+    Invalid-Boolean: "Your last argument must be either true or false!"
+    Teleport-Error: "Location does not exist!"
+    Block-Not-In-Composition: "Block is not in composition"
+    Invalid-Reset-Mode: "&cInvalid reset mode! Use: time, percentage, both"
+    Material-In-Composition: "Material is already in composition!"
+    Chance-Over-100: "Chance would be over 100%"
+  GUI:
+    Mine-Deleted: "Kicked out of mine menu!"
+    Block-Deleted: "Kicked out of block menu!"
+    Loot-Table-Change: "Loot table changed!"
+    First-Page: "You are already on the first page"
+    Last-Page: "You are on the last page"
+    Mine-Doesnt-Exist: "&cThe mine you tried to open doesn't exist anymore!"

--- a/src/main/resources/messages_es.yml
+++ b/src/main/resources/messages_es.yml
@@ -1,0 +1,326 @@
+Time:
+  Seconds: "segundos"
+  Second: "ségundo"
+  Minutes: "minutos"
+  Minute: "minuto"
+  Hours: "horas"
+  Hour: "hora"
+
+GUI:
+  Universal:
+    Previous-Page:
+      Name: "&6&lPágina anterior"
+      Lore:
+        - ""
+        - "&7Abre la página anterior si existe una"
+    Next-Page:
+      Name: "&6&lSiguente página"
+      Lore:
+        - ""
+        - "&7Abre la siguiente página si existe una"
+    Close:
+      Name: "&4&lCerrar"
+      Lore:
+        - ""
+        - "&7Cierra el menú"
+    Back-To-Mine-Menu:
+      Name: "&6&lVolver"
+      Lore:
+        - ""
+        - "&7Vuelve al menú de mina"
+    Back-To-Composition-Menu:
+      Name: "&6&lVolver"
+      Lore:
+        - ""
+        - "&7Vuelve al menú de composición"
+    Back-To-Block-Menu:
+      Name: "&6&lVolver"
+      Lore:
+        - ""
+        - "&7Volver al menú de bloque"
+    Increase-By: "&aAumentar por %number%"
+    Decrease-By: "&cReducir por %number%"
+  Mine-List-Menu:
+    Title: "&bMinas"
+  Mine-Menu:
+    Title: "&b%mine%"
+    Items:
+      Configure-Composition:
+        Name: "&6Configurar composición"
+        Lore:
+          - "&bComposición: &c%chance%%"
+      Configure-Delay:
+        Name: "&6Configurar el temporizador de reinicio"
+        Lore:
+          - "&bReiniciar temporizador: &c%delay%"
+          - "&bReniciar porcentaje: &c%percentage%"
+      Configure-Percentage:
+        Name: "&6Configurar porcentaje de reinicio"
+        Lore:
+          - "&bReniciar porcentaje: &c%percentage%"
+          - "&bReiniciar temporizador: &c%delay%"
+      Warn:
+        Active:
+          Name: "&aAvisa sobre el reinicio"
+        Inactive:
+          Name: "&7No avisa al reiniciar"
+        Lore:
+          - "&bSeleccione si la mina debería avisar durante el reinicio"
+      Warn-Global:
+        Active:
+          Name: "&aAvisa globalmente"
+        Inactive:
+          Name: "&7No avisa globalmente"
+        Lore:
+          - "&bSeleccione si la mina debería avisar globalmente"
+      Warn-Hotbar:
+        Active:
+          Name: "&aMuestra los segundos en la barra de acceso directo"
+        Inactive:
+          Name: "&7No muestra los segundos en la barra de acceso directo"
+        Lore:
+          - "&bSeleccione si la mina debe mostrar los segundos restantes en la barra de acceso directo"
+      Teleport-Players:
+        Active:
+          Name: "&aTeletransportar a los jugadores al reiniciarse"
+        Inactive:
+          Name: "&7No teletransportar a los jugadores al reiniciarse"
+        Lore:
+          - "&bSeleccione si la mina debería de teletransportar a los jugadores"
+          - "&bque se encuentren dentro de la mina durante el reinicio"
+      Teleport-Players-To-Reset-Location:
+        Active:
+          Name: "&aTeletransporta a los jugadores a un punto de reinicio"
+        Inactive:
+          Name: "&7Teletransporta a los jugadores encima de la mina"
+        Lore:
+          - "&bSeleccione si la mina debería de teletransportar a los jugadores"
+          - "&ba un punto de reinicio en lugar de sólo encima de la mina"
+          - "&6&lNOTAS: &7Asegúrate de que tienes un punto de reinicio"
+          - "&7usando /cm setresettp. Teletransportar jugadores"
+          - "&7debe estar activado para que esto surta efecto"
+      Replace-Mode:
+        Active:
+          Name: "&aModo de reemplazo activado"
+        Inactive:
+          Name: "&7Modo de reemplazo desactivado"
+        Lore:
+          - "&bSeleccione si la mina sólo debe remplazar &lAIRE"
+      Efficiency-Lvl:
+        Name: "&6Configure el min. nivel de eficiencia"
+        Lore:
+          - "&bNivel mínimo de eficiencia para romper los bloques: &c%level%"
+          - ""
+          - "&6&lNOTA: &bDebe ser Admin o tener el permiso"
+          - "&bcatamines.break evitar esto!"
+      Warn-Distance:
+        Name: "&6Configurar la distancia de aviso"
+        Lore:
+          - "&bDistancia de aviso: &c%distance%"
+      Reset-Mine:
+        Name: "&cReiniciar mina"
+      Teleport:
+        Name: "&5Teletransportar a mina"
+        Lore:
+          - "&bTe teletransporta a la mina"
+      Delete:
+        Name: "&4&lEliminar mina"
+      Start-Stop:
+        Active:
+          Name: "&aMina activada"
+        Inactive:
+          Name: "&7Mina desactivada"
+        Lore:
+          - "&bSeleccione si la mina debería de reiniciarse automáticamente"
+      Back:
+        Name: "&4&lVolver"
+        Lore:
+          - ""
+          - "&7Vuelve al menú de mina"
+      Running:
+        Active:
+          Name: "&aLa mina está funcionando actualmente"
+          Lore:
+            - "&7Muestra si la mina está funcionando actualmente."
+            - "&7Por lo contrario, mostrará el por qué no."
+        Inactive:
+          Name: "&7La mina no está funcionando debido a:"
+          Reasons:
+            Invalid-Region: "&cSu región es inválida"
+            Stopped: "&cEstá parada"
+            No-Composition: "&cNo tiene ninguna composición"
+            Invalid-Delay: "&cSu temporizador de reinicio es %delay%"
+  Composition-Menu:
+    Title: "&bComposición: &c%chance%%"
+    Items:
+      Composition-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bPorcentaje de aparición: &c%chance%%"
+          - ""
+          - "&aPresioname usando clic izquierdo para configurar"
+      Info:
+        Name: "&6Información:"
+        Lore:
+          - "&aAñadir elementos mediante izquierda/derecha"
+          - "&aHaciendo clic en ellos en tu inventario."
+          - ""
+          - "&cEliminar elementos haciendo clic derecho"
+          - "&csobre ellos en la lista de composición"
+  Composition-Block-Menu:
+    Title: "&bPorcentaje de aparición: &c%blockChance%% / %compChance%%"
+    Items:
+      Current-Block:
+        Name: "%!unchangeable! internal material name%"
+        Lore:
+          - "&f%blockdata%"
+          - ""
+          - "&bPorcentaje de aparición: &c%blockChance%%"
+          - "&bPorcentaje de composición: &c%compChance%%"
+      Change-Table:
+        Name: "&6Modificar tabla de botín"
+      Configure-Table:
+        Name: "&6Configurar porcentaje de drops de la tabla de botín"
+      Add-Loot-Table:
+        Active:
+          Name: "&aLa tabla de botín es añadida encima de los drop default"
+        Inactive:
+          Name: "&7La tabla de botín anula los drops predeterminados"
+        Lore:
+          - "&bSeleccione si desea anular los drops predeterminados"
+          - "&bde este bloque, o si quiere añadir un drop en concreto"
+          - "&bpor encima de su drop predeterminado."
+          - "&6&lNOTA: &bSi la tabla de botín está vacía, esto"
+          - "&bes ignorado."
+  Change-Loot-Table-Menu:
+    Title: "&bInsertar elementos en la tabla de botín"
+    Items:
+      Save-Table:
+        Name: "&aGuardar tabla de botín"
+        Message: "&aTabla de botín guardada."
+  Loot-Table-List-Menu:
+    Title: "&bConfigurar probabilidad de soltar objetos"
+    Items:
+      Drop-Item:
+        Name: "!unchangeable! internal material name"
+        Lore:
+          - ""
+          - "&bProbabilidad de soltar objeto: &c%chance%%"
+  Configure-Item-Drop-Chances-Menu:
+    Title: "&bProbabilidad de soltar objeto: &c%itemChance%/100%"
+    Items:
+      Current-Item: "!unchangeable! internal item"
+  Reset-Delay-Menu:
+    Title: "&bConfigurar temporizador de reinicio: &c%delay%"
+    Items:
+      Current-Delay:
+        Name: "&bTemporizador actual: &c%delay%"
+      Switch:
+        Name: "&6Cambia modos"
+        Lore:
+          - ""
+          - "&bCambia el modo actual a &6porcentaje"
+  Reset-Percentage-Menu:
+    Title: "&bConfigurar porcentaje de reinicio: &c%percentage%%"
+    Items:
+      Current-Percentage:
+        Name: "&bPorcentaje actual: &c%percentage%"
+      Switch:
+        Name: "&6Cambia modos"
+        Lore:
+          - ""
+          - "&bCambia el modo actual a &6temporizador"
+  Efficiency-Menu:
+    Title: "&bNivel de eficiencia mínimo: &c%level%"
+    Items:
+      Current-Level:
+        Name: "&bMínimo nivel de eficiencia picar en la mina: &c%level%"
+        Lore:
+          - "&bMínimo nivel de eficiencia para romper bloques: &c%level%"
+          - ""
+          - "&6&lNOTA: &bDebe ser Admin o tener el permiso"
+          - "&bcatamines.break evitar esto!"
+  Warn-Distance-Menu:
+    Title: "&bDistancia de aviso: &c%distance%"
+    Items:
+      Current-Distance:
+        Name: "&bDistancia actual: &c%distance%"
+
+Commands:
+  Create: "La mina &b%mine% &7ha sido creada."
+  Delete: "La mina &b%mine% &7ha sido eliminada."
+  Delay: "Asignar temporizador de reinicio a &a%seconds% &7segundos."
+  Set:
+    Success: "&b%material% &7asignado a la mina &a%mine%&7. Tienes un &6%remainingChance%% &7restante para asignar."
+    Error: "%chance-over-100%. Tienes un &6%remainingChance%% &7sobrante."
+  Unset:
+    Clear: "La composición de la mina &a%mine% &7ha sido despejada"
+    Remove:
+      Success: "&b%material% &7ha sido eliminado. Tienes un &a%remainingChance%% &7sobrante."
+      Error: "&b%material% &7no estaba en la composición de la mina %mine%&7. Tienes un &a%remainingChance%% &7sobrante."
+  Reset: "La mina ha sido reiniciada."
+  Teleport:
+    Self: "Teletransportado a la mina &b%mine%."
+    Other: "Jugador &6%player% teletransportado &7a mina &b%mine%"
+  Set-Teleport: "Colocar punto de teletransporte para mina &b%mine%."
+  Set-Reset-Teleport: "Colocar teletransporte de reinicio para mina &b%mine%. &7También cambia teleportPlayersToResetLocation a &atrue"
+  Flag:
+    Move-Region: "Región movida de mina &c%mine%."
+    Rename: "Renombrada &b%oldmine% &7a &a%newmine%."
+    Replace-Mode: "Establecer el modo de reemplazo de &b%mine% &7a &a%arg%."
+    Teleport-Players: "Teletransporte de jugadores de mina &b%mine% &7asignado a &a%arg%."
+    Warn:
+      Warn-Hotbar: "Avisos de mina &b%mine% &7asignados a &a%arg%."
+      Warn-Enable: "Avisos de mina &b%mine% &7asignados a &a%arg%."
+      Warn-Global: "Avisos globales de mina &b%mine% &7asignados a &a%arg%."
+      Warn-Message: "&aMensaje de aviso actualizado."
+      Reset-Message: "&aMensaje de reinicio actualizado."
+      Warn-Distance: "Distancia de aviso mina &b%mine% &7asignado a &a%arg%."
+      Warn-Seconds: "&aSegundos de aviso actualizados."
+  Start: "&aIniciada %mine%."
+  Stop: "&cDetenida %mine%."
+  Start-Tasks: "&aIniciadas todas las tareas de la mina"
+  Stop-Tasks: "&cDetenidas todas las tareas de la mina"
+  Sync: "&aSynced all mines"
+  Toggle-Auto-Inv:
+    Enabled: "&aAuto-inventario ahora está &2activado&a. Los drops de la mina irán directamente al inventario del jugador."
+    Disabled: "&cAuto-inventario ahora está &4desactivado&c. Los drops de la mina caerán al suelo normalmente."
+  Reload:
+    All: "&aEl plugin ha sido recargado."
+    Mines: "&aLas minas han sido recargadas."
+    Config: "&aLa configuración ha sido recargada."
+    Messages: "&aLos mensajes han sido recargados."
+    Properties: "&aLas propiedades han sido recargadas."
+
+Error-Messages:
+  No-Permission: "&cNo tienes permis opara hacer eso!"
+  Only-Players: "&cSolo jugadores puden ejecutar este comando!"
+  Unknown-Command: "Comando desconocido."
+  Unknown-Flag: "Propiedad desconocida."
+  Player-Not-Found: "el jugador &6%player% &7no ha sido encontrado!"
+  Mine:
+    Incomplete-Region: "Debes seleccionar una región primero!"
+    Not-Exist: "La mina no existe!"
+    Exist: "La mina ya existe actualmente!"
+    Cant-Reset: "No se puede reiniciar la mina!"
+    Material-Not-Found: "Material no encontrado!"
+    Not-Number: "Tu probabilidad debe ser un numero!"
+    Not-Percentage: "Tu probabilidad debe ser un porcentaje!"
+    Invalid-Chance: "Tu probabilidad debe estar entre 0 y 100%!"
+    Material-Not-Solid: "El material debe ser un bloque sólido!"
+    Invalid-Block-Configuration: "Configuración inválida de bloque!"
+    Invalid-Boolean: "Tu último argumento debe ser true o false!"
+    Teleport-Error: "La localización no existe!"
+    Block-Not-In-Composition: "El bloque no está en la composición"
+    Invalid-Region: "&cLa región es inválida!"
+    Material-In-Composition: "Este material ya está en la composición!"
+    Chance-Over-100: "El porcentaje deseado superaría el 100%"
+  GUI:
+    Mine-Deleted: "Expulsado del menú de mina!"
+    Block-Deleted: "Expulsado del menú de bloque!"
+    Loot-Table-Change: "Tabla de botín cambiada!"
+    First-Page: "Ya te encuentras en la primera página"
+    Last-Page: "Ya te encuentras en la última página"
+    Mine-Doesnt-Exist: "&cLa mina a la que intentaste acceder ya no existe!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,22 +1,22 @@
-name: ${pluginName}
-version: ${version}
-main: me.catalysmrl.catamines.CataMines
-api-version: 1.16
+name: CataMines
+version: '${project.version}'
+main: de.c4t4lysm.catamines.CataMines
+api-version: 1.13
 authors: [ CatalysmRL (C4t4lysm) ]
-description: ${description}
+description: §6[§bCata§aMines§6] §7Mines plugin
 load: POSTWORLD
 depend: [ WorldEdit ]
 softdepend: [ PlaceholderAPI , MultiverseCore ]
 
 commands:
   catamines:
-    description: CataMines command
-    usage: /<command>
-    aliases: [ "cm" , "cmine", "cmines" ]
+    description: §7Contains every mine manipulation command.
+    usage: §b/<command>
+    aliases: [ "cm" , "cmines", "cmine" ]
 
 permissions:
   catamines.*:
-    description: Grants access to every command.
+    description: §7Grants access to every command.
     default: op
     children:
       catamines.help: true
@@ -28,6 +28,8 @@ permissions:
       catamines.set: true
       catamines.unset: true
       catamines.resetmode: true
+      catamines.setallresetmode: true
+      catamines.setallmine: true
       catamines.setdelay: true
       catamines.resetpercentage: true
       catamines.flag: true
@@ -39,67 +41,77 @@ permissions:
       catamines.starttasks: true
       catamines.stoptasks: true
       catamines.reload: true
-      catamines.minefficiency.bypass: true
+      catamines.break: true
+      catamines.toggleautoinv: true
   catamines.help:
-    description: Lets you list all mine commands.
+    description: §7Lets you list all mine commands.
     default: op
   catamines.create:
-    description: Lets you create a mine.
+    description: §7Lets you create a mine.
     default: op
   catamines.delete:
-    description: Lets you delete a mine.
+    description: §7Lets you delete a mine.
     default: op
   catamines.gui:
-    description: Lets you open the gui
+    description: §7Lets you open the gui
     default: op
   catamines.list:
-    description: Lets you list all mines.
+    description: §7Lets you list all mines.
     default: op
   catamines.info:
-    description: Lets you display info of a mine.
+    description: §7Lets you display info of a mine.
     default: op
   catamines.set:
-    description: Lets you set the blocks of a mine.
+    description: §7Lets you set the blocks of a mine.
     default: op
   catamines.unset:
-    description: Lets you unset the blocks of a mine.
+    description: §7Lets you unset the blocks of a mine.
     default: op
   catamines.resetmode:
-    description: Lets you set the reset mode of a mine.
+    description: §7Lets you set the reset mode of a mine.
+    default: op
+  catamines.setallresetmode:
+    description: §7Lets you set the reset mode of all mines at once.
+    default: op
+  catamines.setallmine:
+    description: §7Lets you set the timer or percentage of all mines at once.
     default: op
   catamines.setdelay:
-    description: Lets you set the reset delay of a mine.
+    description: §7Lets you set the reset delay of a mine.
     default: op
   catamines.resetpercentage:
-    description: Lets you set the reset percentage of a mine.
+    description: §7Lets you set the reset percentage of a mine.
     default: op
   catamines.flag:
-    description: Lets you configure every flag of a mine.
+    description: §7Lets you configure every flag of a mine.
     default: op
   catamines.reset:
-    description: Lets you manually reset a mine
+    description: §7Lets you manually reset a mine
     default: op
   catamines.setteleport:
-    description: Lets you set a teleport location of a mine.
+    description: §7Lets you set a teleport location of a mine.
     default: op
   catamines.teleport:
-    description: Lets you teleport to a mine.
+    description: §7Lets you teleport to a mine.
     default: op
   catamines.start:
-    description: Lets you start a mine.
+    description: §7Lets you start a mine.
     default: op
   catamines.stop:
-    description: Lets you stop a mine.
+    description: §7Lets you stop a mine.
     default: op
   catamines.starttasks:
-    description: Starts all mine tasks
+    description: §7Starts all mine tasks
     default: op
   catamines.stoptasks:
-    description: Stops all mine tasks
+    description: §7Stops all mine tasks
     default: op
   catamines.reload:
-    description: Lets you reload the plugin.
+    description: §7Lets you reload the plugin.
     default: op
-  catamines.minefficiency.bypass:
-    description: Lets you bypass min. mine efficiency lvl to break blocks.
+  catamines.break:
+    description: §7Lets you bypass min. mine efficiency lvl to break blocks.
+    default: op
+  catamines.toggleautoinv:
+    description: §7Lets you toggle automatic inventory collection for mine drops server-wide.
     default: op


### PR DESCRIPTION
Hey! i felt few things were missing. Nothing crazy, just features I personally needed and figured others might find useful too.

Fortune enchantment support - Blocks broken inside mine regions now properly respect the Fortune enchantment on the player's tool. Before this, Fortune did nothing inside mines which felt really wrong. It works for both custom loot tables (respects the fortune: true flag per item) and vanilla drops.

BOTH reset mode - The TIME_PERCENTAGE mode was already in the code but completely unreachable, you couldn't set it via command or GUI. I wired it up fully. Mines now default to this mode on creation since it makes the most sense (reset on timer OR when enough blocks are mined, whichever comes first). Existing saved mines are unaffected. You can set it with /cm resetmode mine both or cycle through modes in the GUI.

Bulk commands - Three new commands for server admins managing lots of mines at once. /cm setallresetmode to change reset mode on every mine at once, /cm setallmine timer seconds to set delay on all mines, /cm setallmine percentage value to set reset percentage on all mines.

GUI improvements - Added a dedicated Reset Mode button in the mine menu, click it to cycle between TIME, PERCENTAGE, and BOTH without typing commands. The mine list now shows each mine's current reset mode in its lore so you can see everything at a glance.

Auto Inventory - Items that mined in catamines region, now can directly sent to player's inventory via /cm toggleautoinv (the command is for admins to toggle server auto inv function)

All new commands have proper permissions, tab completion, and messages